### PR TITLE
feat: make pcre2 an optional cargo feature with docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to fastokens
+
+Thank you for your interest in contributing. The notes below cover the development workflow and testing requirements.
+
+## Building
+
+```sh
+cargo build
+```
+
+To build without the optional `pcre2` C dependency (pure-Rust build):
+
+```sh
+cargo build --no-default-features
+```
+
+## Testing
+Run the test suite to catch regressions:
+
+```sh
+# Default build — pcre2 JIT fast path enabled
+cargo test
+
+# Pure-Rust build — fancy-regex fallback, no libpcre2-8 required
+cargo test --no-default-features
+```
+
+## Code style
+
+After making any changes to Rust source files, run the formatter before committing:
+
+```sh
+cargo fmt
+```
+
+## Feature flags
+
+| Feature | Default | Notes |
+|---------|---------|-------|
+| `pcre2` | on | Links to `libpcre2-8` via `pcre2-sys`. Disable with `--no-default-features` if the system library is unavailable. |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -558,12 +558,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -701,19 +695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,15 +711,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -986,12 +958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,9 +991,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1114,12 +1078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1232,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1309,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1341,9 +1299,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -1431,16 +1389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
 ]
 
 [[package]]
@@ -1626,15 +1574,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1686,18 +1634,18 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -1708,19 +1656,13 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1933,15 +1875,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2026,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2166,12 +2108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,15 +2212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2344,28 +2271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,18 +2281,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2655,88 +2548,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,15 @@ name = "fastokens"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["pcre2"]
+pcre2 = ["dep:pcre2"]
+
 [dependencies]
 daachorse = "1.0.0"
 fancy-regex = "0.17.0"
 memchr = "2"
-pcre2 = "0.2"
+pcre2 = { version = "0.2", optional = true }
 hf-hub = "0.4.3"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ tokenizer = Tokenizer.from_model("deepseek-ai/DeepSeek-V3.2")
 tokens = tokenizer.encode("A very long prompt that is now lightning fast.")
 ```
 
+## Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `pcre2` | **enabled** | Uses the PCRE2 JIT engine for faster regex matching in the `Split` pre-tokenizer. Requires `libpcre2-8` on the system. When disabled, the pure-Rust `fancy-regex` engine is used as a fallback with identical output. |
+
+To opt out of the native C dependency (e.g. in environments where `libpcre2-8` is not available):
+
+```toml
+fastokens = { version = "...", default-features = false }
+```
+
 ## Acknowledgements
 
 This library builds on the well-known and widely used Hugging Face tokenizers library and uses code written for HF tokenizers in several flows.

--- a/examples/profile_sample.rs
+++ b/examples/profile_sample.rs
@@ -113,8 +113,8 @@ fn main() -> Result<()> {
     println!("Warm encode: {:.2} ms", warm_time.as_secs_f64() * 1000.0);
 
     // Step 4: HF comparison
-    let hf = tokenizers::Tokenizer::from_pretrained(model_name, None)
-        .map_err(|e| anyhow::anyhow!(e))?;
+    let hf =
+        tokenizers::Tokenizer::from_pretrained(model_name, None).map_err(|e| anyhow::anyhow!(e))?;
     let t0 = Instant::now();
     let _ = hf
         .encode_fast(input, true)

--- a/examples/profile_stages.rs
+++ b/examples/profile_stages.rs
@@ -27,7 +27,10 @@ fn main() -> Result<()> {
         let ids = tokenizer.encode(&input).unwrap();
         std::hint::black_box(ids);
     }
-    println!("Full encode:    {:.2} ms avg ({n} iters)", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "Full encode:    {:.2} ms avg ({n} iters)",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Build the initial pre-tokenized string
     use fastokens::pre_tokenized::{PreTokenizedString, Split as PtSplit};
@@ -46,12 +49,8 @@ fn main() -> Result<()> {
 
     // Create Split pre-tokenizer directly
     let split_pattern = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
-    let split = fastokens::Split::from_config(
-        &json!({"Regex": split_pattern}),
-        "Isolated",
-        false,
-    )
-    .unwrap();
+    let split =
+        fastokens::Split::from_config(&json!({"Regex": split_pattern}), "Isolated", false).unwrap();
 
     // Create ByteLevel pre-tokenizer directly
     let byte_level = fastokens::ByteLevel::from_config(false, true, false).unwrap();
@@ -66,7 +65,10 @@ fn main() -> Result<()> {
         let mut pts = base_pts.clone();
         split.pre_tokenize(&mut pts).unwrap();
     }
-    println!("Split only:     {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "Split only:     {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile ByteLevel only (after Split)
     let mut after_split = base_pts.clone();
@@ -82,7 +84,10 @@ fn main() -> Result<()> {
         let mut pts = after_split.clone();
         byte_level.pre_tokenize(&mut pts).unwrap();
     }
-    println!("ByteLevel only: {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "ByteLevel only: {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile BPE tokenize (non-fused, via full pre-tokenizer)
     let model = tokenizer.model();
@@ -98,9 +103,15 @@ fn main() -> Result<()> {
         for s in after_pretok.splits() {
             let t = after_pretok.split_text(s);
             unique.insert(t);
-            if t.len() <= 4 { single_token += 1; }
+            if t.len() <= 4 {
+                single_token += 1;
+            }
         }
-        println!("Unique splits: {} (short <=4 bytes: {})", unique.len(), single_token);
+        println!(
+            "Unique splits: {} (short <=4 bytes: {})",
+            unique.len(),
+            single_token
+        );
     }
 
     {
@@ -108,10 +119,15 @@ fn main() -> Result<()> {
     }
     let t = Instant::now();
     for _ in 0..n {
-        let ids = after_pretok.tokenize(|t, out| model.tokenize_into(t, out)).unwrap();
+        let ids = after_pretok
+            .tokenize(|t, out| model.tokenize_into(t, out))
+            .unwrap();
         std::hint::black_box(ids);
     }
-    println!("BPE tokenize:   {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "BPE tokenize:   {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile fused BPE tokenize (Split-only + fused BPE)
     {
@@ -123,10 +139,15 @@ fn main() -> Result<()> {
     for _ in 0..n {
         let mut pts = base_pts.clone();
         split.pre_tokenize(&mut pts).unwrap();
-        let ids = pts.tokenize(|t, out| model.tokenize_into_fused(t, out)).unwrap();
+        let ids = pts
+            .tokenize(|t, out| model.tokenize_into_fused(t, out))
+            .unwrap();
         std::hint::black_box(ids);
     }
-    println!("Fused tok:      {:.2} ms avg (Split + fused BPE)", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "Fused tok:      {:.2} ms avg (Split + fused BPE)",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile BPE tokenize sequential (no rayon)
     {
@@ -134,10 +155,15 @@ fn main() -> Result<()> {
     }
     let t = Instant::now();
     for _ in 0..n {
-        let ids = after_pretok.tokenize_sequential_pub(|t, out| model.tokenize_into(t, out)).unwrap();
+        let ids = after_pretok
+            .tokenize_sequential_pub(|t, out| model.tokenize_into(t, out))
+            .unwrap();
         std::hint::black_box(ids);
     }
-    println!("BPE seq:        {:.2} ms avg (sequential, no rayon)", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "BPE seq:        {:.2} ms avg (sequential, no rayon)",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile iteration overhead only (no BPE, just iterate splits)
     let t = Instant::now();
@@ -148,7 +174,10 @@ fn main() -> Result<()> {
         }
         std::hint::black_box(count);
     }
-    println!("Iter only:      {:.2} ms avg (iterate splits, no BPE)", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "Iter only:      {:.2} ms avg (iterate splits, no BPE)",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile build_pre_tokenized (added tokens + NFC + buffer copy)
     {
@@ -159,7 +188,10 @@ fn main() -> Result<()> {
         let pts = tokenizer.build_pre_tokenized(&input);
         std::hint::black_box(pts);
     }
-    println!("build_pre_tok:  {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "build_pre_tok:  {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile NFC normalization alone
     let normalizer = tokenizer.normalizer();
@@ -175,7 +207,10 @@ fn main() -> Result<()> {
             std::hint::black_box(r);
         }
     }
-    println!("NFC normalize:  {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "NFC normalize:  {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile just buffer copy (to measure memcpy cost)
     let t = Instant::now();
@@ -183,7 +218,10 @@ fn main() -> Result<()> {
         let s = input.to_string();
         std::hint::black_box(s);
     }
-    println!("String copy:    {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / n as f64);
+    println!(
+        "String copy:    {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / n as f64
+    );
 
     // Profile contains("<|") prefilter
     let t = Instant::now();
@@ -191,7 +229,10 @@ fn main() -> Result<()> {
         let r = input.contains("<|");
         std::hint::black_box(r);
     }
-    println!("contains <|:    {:.2} ms avg (100 iters)", t.elapsed().as_secs_f64() * 1000.0 / 100.0);
+    println!(
+        "contains <|:    {:.2} ms avg (100 iters)",
+        t.elapsed().as_secs_f64() * 1000.0 / 100.0
+    );
 
     // Profile NFC on the actual input with 100 iters for accuracy
     let t = Instant::now();
@@ -201,7 +242,10 @@ fn main() -> Result<()> {
             std::hint::black_box(r);
         }
     }
-    println!("NFC (100 iter): {:.2} ms avg", t.elapsed().as_secs_f64() * 1000.0 / 100.0);
+    println!(
+        "NFC (100 iter): {:.2} ms avg",
+        t.elapsed().as_secs_f64() * 1000.0 / 100.0
+    );
 
     // Profile from_text (string allocation + copy)
     let t = Instant::now();
@@ -209,7 +253,10 @@ fn main() -> Result<()> {
         let pts = PreTokenizedString::from_text(&input);
         std::hint::black_box(pts);
     }
-    println!("from_text:      {:.2} ms avg (100 iters)", t.elapsed().as_secs_f64() * 1000.0 / 100.0);
+    println!(
+        "from_text:      {:.2} ms avg (100 iters)",
+        t.elapsed().as_secs_f64() * 1000.0 / 100.0
+    );
 
     // Profile memchr for '<'
     let t = Instant::now();
@@ -217,7 +264,10 @@ fn main() -> Result<()> {
         let r = input.as_bytes().iter().position(|&b| b == b'<');
         std::hint::black_box(r);
     }
-    println!("find '<':       {:.2} ms avg (100 iters)", t.elapsed().as_secs_f64() * 1000.0 / 100.0);
+    println!(
+        "find '<':       {:.2} ms avg (100 iters)",
+        t.elapsed().as_secs_f64() * 1000.0 / 100.0
+    );
 
     println!("\nDone.");
     Ok(())

--- a/examples/simple_bench.rs
+++ b/examples/simple_bench.rs
@@ -115,7 +115,14 @@ fn load_dataset(dataset: &str, max_items: Option<usize>, verbose: bool) -> Resul
     Ok(samples)
 }
 
-fn print_summary(label: &str, n: usize, total_chars: u64, total_tokens: u64, total_hf: Duration, total_ft: Duration) {
+fn print_summary(
+    label: &str,
+    n: usize,
+    total_chars: u64,
+    total_tokens: u64,
+    total_hf: Duration,
+    total_ft: Duration,
+) {
     let nf = n as f64;
     let hf_ms = total_hf.as_secs_f64() * 1000.0;
     let ft_ms = total_ft.as_secs_f64() * 1000.0;
@@ -179,7 +186,9 @@ fn bench_sequential(
             .context("HF tokenizer encode failed")?;
         let enc_hf = enc_hf.get_ids();
         let t1 = Instant::now();
-        let enc = tokenizer.encode_with_special_tokens(chunk, true).context("fastokens encode failed")?;
+        let enc = tokenizer
+            .encode_with_special_tokens(chunk, true)
+            .context("fastokens encode failed")?;
         let t2 = Instant::now();
 
         if enc_hf != enc {
@@ -233,7 +242,14 @@ fn bench_sequential(
     }
 
     pb.finish();
-    print_summary("Benchmark Summary", chunks.len(), total_chars, total_tokens, total_hf, total_ft);
+    print_summary(
+        "Benchmark Summary",
+        chunks.len(),
+        total_chars,
+        total_tokens,
+        total_hf,
+        total_ft,
+    );
     Ok(())
 }
 
@@ -254,9 +270,11 @@ fn bench_batched(
     } else {
         let pb = ProgressBar::new(num_batches as u64);
         pb.set_style(
-            ProgressStyle::with_template("[{elapsed_precise}] [{bar:40}] {pos}/{len} batches ({eta})")
-                .expect("valid template")
-                .progress_chars("=> "),
+            ProgressStyle::with_template(
+                "[{elapsed_precise}] [{bar:40}] {pos}/{len} batches ({eta})",
+            )
+            .expect("valid template")
+            .progress_chars("=> "),
         );
         pb
     };
@@ -395,9 +413,22 @@ fn main() -> Result<()> {
     }
 
     if let Some(batch_size) = args.batch_size {
-        bench_batched(&chunks, &hf_tokenizer, &tokenizer, batch_size, args.verbose, csv_writer.as_mut())?;
+        bench_batched(
+            &chunks,
+            &hf_tokenizer,
+            &tokenizer,
+            batch_size,
+            args.verbose,
+            csv_writer.as_mut(),
+        )?;
     } else {
-        bench_sequential(&chunks, &hf_tokenizer, &tokenizer, args.verbose, csv_writer.as_mut())?;
+        bench_sequential(
+            &chunks,
+            &hf_tokenizer,
+            &tokenizer,
+            args.verbose,
+            csv_writer.as_mut(),
+        )?;
     }
 
     Ok(())

--- a/src/added_tokens.rs
+++ b/src/added_tokens.rs
@@ -128,11 +128,7 @@ impl AddedTokens {
             ),
             2 => self.split_prefilter(
                 input,
-                memchr::memchr2_iter(
-                    self.start_bytes[0],
-                    self.start_bytes[1],
-                    input.as_bytes(),
-                ),
+                memchr::memchr2_iter(self.start_bytes[0], self.start_bytes[1], input.as_bytes()),
             ),
             3 => self.split_prefilter(
                 input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,6 @@ impl Tokenizer {
 
         PreTokenizedString::new(buffer, splits)
     }
-
 }
 
 #[cfg(test)]
@@ -435,7 +434,10 @@ mod tests {
 
         for (input, batch_result) in inputs.iter().zip(&batch_results) {
             let sequential_result = ours.encode(input).unwrap();
-            assert_eq!(batch_result, &sequential_result, "batch mismatch for {input:?}");
+            assert_eq!(
+                batch_result, &sequential_result,
+                "batch mismatch for {input:?}"
+            );
         }
     }
 
@@ -448,7 +450,9 @@ mod tests {
         assert!(ours.vocab_size() > 0);
 
         let token_str = ours.id_to_token(0).expect("token 0 should exist");
-        let id = ours.token_to_id(token_str).expect("reverse lookup should work");
+        let id = ours
+            .token_to_id(token_str)
+            .expect("reverse lookup should work");
         assert_eq!(id, 0);
     }
 
@@ -469,8 +473,8 @@ mod tests {
         "Z",
         "0",
         "!",
-        "\u{00e9}",       // é (precomposed)
-        "\u{4e2d}",       // 中
+        "\u{00e9}", // é (precomposed)
+        "\u{4e2d}", // 中
         // ── basic text ──
         "Hello, world!",
         "The quick brown fox jumps over the lazy dog.",
@@ -505,9 +509,9 @@ mod tests {
         "\u{00fc}ber stra\u{00df}e gr\u{00f6}\u{00df}e",
         "se\u{00f1}or ni\u{00f1}o a\u{00f1}o",
         // ── Unicode: CJK ──
-        "\u{4f60}\u{597d}\u{4e16}\u{754c}",               // 你好世界
-        "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}",       // こんにちは
-        "\u{c548}\u{b155}\u{d558}\u{c138}\u{c694}",       // 안녕하세요
+        "\u{4f60}\u{597d}\u{4e16}\u{754c}",         // 你好世界
+        "\u{3053}\u{3093}\u{306b}\u{3061}\u{306f}", // こんにちは
+        "\u{c548}\u{b155}\u{d558}\u{c138}\u{c694}", // 안녕하세요
         // ── Unicode: Cyrillic ──
         "\u{041f}\u{0440}\u{0438}\u{0432}\u{0435}\u{0442} \u{043c}\u{0438}\u{0440}",
         // ── Unicode: Arabic ──
@@ -517,11 +521,11 @@ mod tests {
         // ── Unicode: Emoji ──
         "\u{1f600}\u{1f680}\u{2764}\u{fe0f}",
         "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466}",
-        "\u{1f1fa}\u{1f1f8}",                              // 🇺🇸
+        "\u{1f1fa}\u{1f1f8}", // 🇺🇸
         // ── Unicode: combining marks (NFD forms) ──
-        "e\u{0301}",                                       // e + combining acute
-        "n\u{0303}",                                       // n + combining tilde
-        "a\u{0308}",                                       // a + combining diaeresis
+        "e\u{0301}", // e + combining acute
+        "n\u{0303}", // n + combining tilde
+        "a\u{0308}", // a + combining diaeresis
         // ── mixed scripts ──
         "Hello \u{4e16}\u{754c} \u{041c}\u{0438}\u{0440}!",
         "User123 wrote: \u{4f60}\u{597d}!",
@@ -557,28 +561,28 @@ mod tests {
         // ── boundary / edge cases ──
         "a\nb\nc\n",
         "# Heading\n\n- item 1\n- item 2\n\n```code```",
-        "\u{ffff}",                                        // max BMP non-character
-        "\u{0080}",                                        // first non-ASCII
-        "\u{07ff}",                                        // max 2-byte UTF-8
-        "\u{0800}",                                        // first 3-byte UTF-8
-        "\u{10000}",                                       // first surrogate-pair range
+        "\u{ffff}",  // max BMP non-character
+        "\u{0080}",  // first non-ASCII
+        "\u{07ff}",  // max 2-byte UTF-8
+        "\u{0800}",  // first 3-byte UTF-8
+        "\u{10000}", // first surrogate-pair range
         // ── unusual / invalid-ish Unicode ──
-        "\u{fffd}",                                        // replacement character
-        "\u{feff}Hello",                                   // BOM prefix
-        "\u{0000}",                                        // null
-        "abc\u{0000}def",                                  // embedded null
-        "\u{fffe}",                                        // non-character
-        "\u{fdd0}",                                        // non-character (FDD0 block)
-        "\u{200b}\u{200c}\u{200d}",                        // zero-width space / ZWNJ / ZWJ
-        "\u{202e}Hello\u{202c}",                           // RTL override + pop directional
-        "\u{0001}\u{0002}\u{001f}\u{007f}",                // C0 controls + DEL
-        "\u{0300}",                                        // lone combining grave (no base)
-        "a\u{0300}\u{0301}\u{0302}\u{0303}\u{0304}",      // 5 combining marks on one base
-        "\u{e000}\u{f8ff}",                                // private use area
-        "\u{01c5}\u{01c8}\u{01cb}",                        // titlecase letters (Dž Lj Nj)
-        "\u{2028}\u{2029}",                                // line / paragraph separators
-        "\u{fff9}\u{fffa}\u{fffb}",                        // interlinear annotation
-        "\u{d7ff}\u{10ffff}",                              // last before surrogates + max codepoint
+        "\u{fffd}",                                  // replacement character
+        "\u{feff}Hello",                             // BOM prefix
+        "\u{0000}",                                  // null
+        "abc\u{0000}def",                            // embedded null
+        "\u{fffe}",                                  // non-character
+        "\u{fdd0}",                                  // non-character (FDD0 block)
+        "\u{200b}\u{200c}\u{200d}",                  // zero-width space / ZWNJ / ZWJ
+        "\u{202e}Hello\u{202c}",                     // RTL override + pop directional
+        "\u{0001}\u{0002}\u{001f}\u{007f}",          // C0 controls + DEL
+        "\u{0300}",                                  // lone combining grave (no base)
+        "a\u{0300}\u{0301}\u{0302}\u{0303}\u{0304}", // 5 combining marks on one base
+        "\u{e000}\u{f8ff}",                          // private use area
+        "\u{01c5}\u{01c8}\u{01cb}",                  // titlecase letters (Dž Lj Nj)
+        "\u{2028}\u{2029}",                          // line / paragraph separators
+        "\u{fff9}\u{fffa}\u{fffb}",                  // interlinear annotation
+        "\u{d7ff}\u{10ffff}",                        // last before surrogates + max codepoint
         // ── potential BPE merge edge cases ──
         "ab",
         "abc",
@@ -596,10 +600,7 @@ mod tests {
     /// Helper: compare both encoding and decoding of every input in `corpus`
     /// between our tokenizer and the HuggingFace tokenizer for a given model.
     /// Returns a list of failure descriptions (empty = all passed).
-    fn compare_encode_decode(
-        model_name: &str,
-        corpus: &[&str],
-    ) -> Vec<String> {
+    fn compare_encode_decode(model_name: &str, corpus: &[&str]) -> Vec<String> {
         let hf = tokenizers::Tokenizer::from_pretrained(model_name, None)
             .unwrap_or_else(|e| panic!("{model_name}: HF load failed: {e}"));
         let ours = Tokenizer::from_model(model_name)
@@ -614,9 +615,7 @@ mod tests {
             let our_ids = match ours.encode(input) {
                 Ok(ids) => ids,
                 Err(e) => {
-                    failures.push(format!(
-                        "  encode error on {input:?}: {e}"
-                    ));
+                    failures.push(format!("  encode error on {input:?}: {e}"));
                     continue;
                 }
             };
@@ -643,9 +642,7 @@ mod tests {
             let our_decoded = match ours.decode(&hf_ids, false) {
                 Ok(d) => d,
                 Err(e) => {
-                    failures.push(format!(
-                        "  decode error on {input:?}: {e}"
-                    ));
+                    failures.push(format!("  decode error on {input:?}: {e}"));
                     continue;
                 }
             };
@@ -673,7 +670,11 @@ mod tests {
     #[test]
     fn correctness_nemotron() {
         let f = compare_encode_decode("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", CORPUS);
-        assert!(f.is_empty(), "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16:\n{}",
+            f.join("\n")
+        );
     }
 
     #[test]
@@ -697,13 +698,21 @@ mod tests {
     #[test]
     fn correctness_mistral_nemo() {
         let f = compare_encode_decode("mistralai/Mistral-Nemo-Instruct-2407", CORPUS);
-        assert!(f.is_empty(), "mistralai/Mistral-Nemo-Instruct-2407:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "mistralai/Mistral-Nemo-Instruct-2407:\n{}",
+            f.join("\n")
+        );
     }
 
     #[test]
     fn correctness_qwen3_nemotron() {
         let f = compare_encode_decode("nvidia/Qwen3-Nemotron-235B-A22B-GenRM", CORPUS);
-        assert!(f.is_empty(), "nvidia/Qwen3-Nemotron-235B-A22B-GenRM:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "nvidia/Qwen3-Nemotron-235B-A22B-GenRM:\n{}",
+            f.join("\n")
+        );
     }
 
     // ── Cache consistency ────────────────────────────────────────────
@@ -743,10 +752,7 @@ mod tests {
         let ours = Tokenizer::from_model(model).unwrap();
 
         // Verify the fused path is active.
-        assert!(
-            ours.split_only.is_some(),
-            "expected fused path for {model}",
-        );
+        assert!(ours.split_only.is_some(), "expected fused path for {model}",);
 
         // Run the same input many times to stress the fused cache.
         let input = "The year 2024 was notable for advances in AI. Models like \
@@ -775,7 +781,11 @@ mod tests {
             "<fim_prefix>code here<fim_suffix>more code<fim_middle>",
         ];
         let f = compare_encode_decode("MiniMaxAI/MiniMax-M2.1", corpus);
-        assert!(f.is_empty(), "MiniMaxAI/MiniMax-M2.1 added tokens:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "MiniMaxAI/MiniMax-M2.1 added tokens:\n{}",
+            f.join("\n")
+        );
     }
 
     /// DeepSeek-V3.2 added tokens.
@@ -789,7 +799,11 @@ mod tests {
             "<|tool▁calls▁begin|>call<|tool▁calls▁end|>",
         ];
         let f = compare_encode_decode("deepseek-ai/DeepSeek-V3.2", corpus);
-        assert!(f.is_empty(), "deepseek-ai/DeepSeek-V3.2 added tokens:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "deepseek-ai/DeepSeek-V3.2 added tokens:\n{}",
+            f.join("\n")
+        );
     }
 
     /// Qwen3 added tokens.
@@ -802,7 +816,11 @@ mod tests {
             "Plain text with no special tokens at all.",
         ];
         let f = compare_encode_decode("Qwen/Qwen3-0.6B", corpus);
-        assert!(f.is_empty(), "Qwen/Qwen3-0.6B added tokens:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "Qwen/Qwen3-0.6B added tokens:\n{}",
+            f.join("\n")
+        );
     }
 
     /// Nemotron added tokens.
@@ -816,7 +834,11 @@ mod tests {
             "No special tokens here.",
         ];
         let f = compare_encode_decode("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", corpus);
-        assert!(f.is_empty(), "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 added tokens:\n{}", f.join("\n"));
+        assert!(
+            f.is_empty(),
+            "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 added tokens:\n{}",
+            f.join("\n")
+        );
     }
 
     // ── Long input stress test ───────────────────────────────────────
@@ -840,7 +862,8 @@ mod tests {
         let hf_ids = hf.encode(input.as_str(), false).unwrap().get_ids().to_vec();
         let our_ids = ours.encode(&input).unwrap();
         assert_eq!(
-            our_ids, hf_ids,
+            our_ids,
+            hf_ids,
             "long input mismatch: {} vs {} tokens",
             our_ids.len(),
             hf_ids.len(),
@@ -863,7 +886,8 @@ mod tests {
         let hf_ids = hf.encode(input.as_str(), false).unwrap().get_ids().to_vec();
         let our_ids = ours.encode(&input).unwrap();
         assert_eq!(
-            our_ids, hf_ids,
+            our_ids,
+            hf_ids,
             "long input mismatch: {} vs {} tokens",
             our_ids.len(),
             hf_ids.len(),
@@ -893,7 +917,11 @@ mod tests {
                 .iter()
                 .filter_map(|item| {
                     let ctx = item.get("context")?.as_str()?;
-                    if ctx.is_empty() { None } else { Some(ctx.to_string()) }
+                    if ctx.is_empty() {
+                        None
+                    } else {
+                        Some(ctx.to_string())
+                    }
                 })
                 .collect();
 
@@ -909,17 +937,29 @@ mod tests {
                     let parts: Vec<String> = messages
                         .iter()
                         .filter_map(|msg| {
-                            let role = msg.get("from").and_then(|v| v.as_str()).unwrap_or("unknown");
+                            let role = msg
+                                .get("from")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown");
                             let value = msg.get("value").and_then(|v| v.as_str())?;
-                            if value.is_empty() { return None; }
+                            if value.is_empty() {
+                                return None;
+                            }
                             Some(format!("[{role}]: {value}"))
                         })
                         .collect();
-                    if parts.is_empty() { None } else { Some(parts.join("\n\n")) }
+                    if parts.is_empty() {
+                        None
+                    } else {
+                        Some(parts.join("\n\n"))
+                    }
                 })
                 .collect();
 
-            ExtendedCorpus { longbench, sharegpt }
+            ExtendedCorpus {
+                longbench,
+                sharegpt,
+            }
         })
     }
 
@@ -991,9 +1031,7 @@ mod tests {
                 let our_decoded = match ours.decode(hf_ids, false) {
                     Ok(d) => d,
                     Err(e) => {
-                        failures.push(format!(
-                            "  decode error on {input_preview:?}: {e}"
-                        ));
+                        failures.push(format!("  decode error on {input_preview:?}: {e}"));
                         continue;
                     }
                 };
@@ -1025,13 +1063,25 @@ mod tests {
         let progress = std::env::var("EXTENDED_PROGRESS").is_ok();
         let corpus = extended_corpus();
         if progress {
-            eprintln!("  {model_name}: longbench ({} samples)", corpus.longbench.len());
+            eprintln!(
+                "  {model_name}: longbench ({} samples)",
+                corpus.longbench.len()
+            );
         }
-        let mut failures = compare_encode_decode_batched(model_name, &corpus.longbench, 10, progress);
+        let mut failures =
+            compare_encode_decode_batched(model_name, &corpus.longbench, 10, progress);
         if progress {
-            eprintln!("  {model_name}: sharegpt ({} samples)", corpus.sharegpt.len());
+            eprintln!(
+                "  {model_name}: sharegpt ({} samples)",
+                corpus.sharegpt.len()
+            );
         }
-        failures.extend(compare_encode_decode_batched(model_name, &corpus.sharegpt, 10, progress));
+        failures.extend(compare_encode_decode_batched(
+            model_name,
+            &corpus.sharegpt,
+            10,
+            progress,
+        ));
         assert!(
             failures.is_empty(),
             "{model_name} extended ({} failures):\n{}",
@@ -1093,5 +1143,4 @@ mod tests {
     fn extended_qwen_small() {
         run_extended("Qwen/Qwen3-0.6B");
     }
-
 }

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -4,8 +4,8 @@ use std::{
     collections::{BinaryHeap, HashMap},
     fmt,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Mutex,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -254,8 +254,12 @@ impl FlatCache {
             let slot = unsafe { self.slots.get_unchecked(idx) };
             let h = slot.hash;
             if h == EMPTY_SLOT {
-                let Ok(len) = u16::try_from(ids.len()) else { return };
-                let Ok(key_len) = u16::try_from(key_bytes.len()) else { return };
+                let Ok(len) = u16::try_from(ids.len()) else {
+                    return;
+                };
+                let Ok(key_len) = u16::try_from(key_bytes.len()) else {
+                    return;
+                };
                 self.count += 1;
                 let offset = self.pool.len() as u32;
                 self.pool.extend_from_slice(ids);
@@ -273,7 +277,9 @@ impl FlatCache {
                 let ks = slot.key_offset as usize;
                 let ke = ks + slot.key_len as usize;
                 if unsafe { self.key_pool.get_unchecked(ks..ke) } == key_bytes {
-                    let Ok(len) = u16::try_from(ids.len()) else { return };
+                    let Ok(len) = u16::try_from(ids.len()) else {
+                        return;
+                    };
                     let offset = self.pool.len() as u32;
                     self.pool.extend_from_slice(ids);
                     let slot = unsafe { self.slots.get_unchecked_mut(idx) };
@@ -312,9 +318,7 @@ impl SharedCache {
         let bytes = key.as_bytes();
         let mut h: u64 = bytes.len() as u64;
         for &b in &bytes[..bytes.len().min(8)] {
-            h = h
-                .wrapping_add(b as u64)
-                .wrapping_mul(0x9E3779B97F4A7C15);
+            h = h.wrapping_add(b as u64).wrapping_mul(0x9E3779B97F4A7C15);
         }
         h as usize & (CACHE_SHARDS - 1)
     }
@@ -466,14 +470,25 @@ impl RankedMergeMap {
         }
         let capacity = (parsed.len() * 2).next_power_of_two();
         let mask = capacity - 1;
-        let mut slots = vec![RankedMergeSlot { key: EMPTY_KEY, rank: 0, id: 0 }; capacity];
+        let mut slots = vec![
+            RankedMergeSlot {
+                key: EMPTY_KEY,
+                rank: 0,
+                id: 0
+            };
+            capacity
+        ];
 
         for (&(t1, t2), &(rank, merged_id)) in parsed {
             let key = pack_pair(t1, t2);
             let mut idx = fx_hash(key) as usize & mask;
             loop {
                 if slots[idx].key == EMPTY_KEY {
-                    slots[idx] = RankedMergeSlot { key, rank, id: merged_id };
+                    slots[idx] = RankedMergeSlot {
+                        key,
+                        rank,
+                        id: merged_id,
+                    };
                     break;
                 }
                 idx = (idx + 1) & mask;
@@ -718,9 +733,8 @@ impl Bpe {
 
         let token_lens: Vec<u16> = (0..=max_token)
             .map(|t| {
-                u16::try_from(vocab_r[&t].len()).map_err(|_| {
-                    format!("token {t} length {} exceeds u16::MAX", vocab_r[&t].len())
-                })
+                u16::try_from(vocab_r[&t].len())
+                    .map_err(|_| format!("token {t} length {} exceeds u16::MAX", vocab_r[&t].len()))
             })
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
@@ -962,7 +976,8 @@ impl Bpe {
                 });
                 // Check pair with previous byte via pre-computed table.
                 if i > 0 {
-                    let (rank, _new_id) = self.byte_pair_initial[prev_byte as usize * 256 + byte as usize];
+                    let (rank, _new_id) =
+                        self.byte_pair_initial[prev_byte as usize * 256 + byte as usize];
                     if rank != u32::MAX {
                         scratch.heap_buf.push(Reverse(MergeEntry::new(
                             rank,
@@ -998,9 +1013,9 @@ impl Bpe {
         scratch.heap.extend((0..n - 1).filter_map(|i| {
             let left = symbols[i].c;
             let right = symbols[i + 1].c;
-            self.merge_adj.get(left, right).map(|(rank, _new_id)| {
-                Reverse(MergeEntry::new(rank, i as u32, left, right))
-            })
+            self.merge_adj
+                .get(left, right)
+                .map(|(rank, _new_id)| Reverse(MergeEntry::new(rank, i as u32, left, right)))
         }));
     }
 
@@ -1047,7 +1062,12 @@ impl Bpe {
             if sym.prev >= 0 {
                 let prev_c = symbols[sym.prev as usize].c;
                 if let Some((rank, _)) = self.merge_adj.get(prev_c, new_id) {
-                    heap.push(Reverse(MergeEntry::new(rank, sym.prev as u32, prev_c, new_id)));
+                    heap.push(Reverse(MergeEntry::new(
+                        rank,
+                        sym.prev as u32,
+                        prev_c,
+                        new_id,
+                    )));
                 }
             }
             let new_next = symbols[pos].next;

--- a/src/post_processors.rs
+++ b/src/post_processors.rs
@@ -139,9 +139,11 @@ impl PostProcessor {
                 single,
                 pair,
                 special_tokens,
-            } => Ok(Self::TemplateProcessing(
-                TemplateProcessing::from_config(single, pair, special_tokens)?,
-            )),
+            } => Ok(Self::TemplateProcessing(TemplateProcessing::from_config(
+                single,
+                pair,
+                special_tokens,
+            )?)),
             PostProcessorConfig::Sequence { processors } => {
                 let steps = processors
                     .into_iter()
@@ -164,11 +166,7 @@ impl PostProcessor {
     ///
     /// Only has an effect when `add_special_tokens` is true and the processor
     /// adds special tokens (e.g. `TemplateProcessing`).
-    pub fn post_process_single(
-        &self,
-        encoded: Vec<u32>,
-        add_special_tokens: bool,
-    ) -> Vec<u32> {
+    pub fn post_process_single(&self, encoded: Vec<u32>, add_special_tokens: bool) -> Vec<u32> {
         if !add_special_tokens {
             return encoded;
         }
@@ -282,10 +280,7 @@ mod tests {
         });
 
         // With special tokens
-        assert_eq!(
-            pp.post_process_single(vec![10, 20], true),
-            vec![1, 10, 20]
-        );
+        assert_eq!(pp.post_process_single(vec![10, 20], true), vec![1, 10, 20]);
         // Without special tokens
         assert_eq!(pp.post_process_single(vec![10, 20], false), vec![10, 20]);
     }

--- a/src/pre_tokenized.rs
+++ b/src/pre_tokenized.rs
@@ -119,7 +119,8 @@ impl PreTokenizedString {
         }
 
         let pool = bpe_pool();
-        let chunk_size = (self.splits.len() + pool.current_num_threads() - 1) / pool.current_num_threads();
+        let chunk_size =
+            (self.splits.len() + pool.current_num_threads() - 1) / pool.current_num_threads();
 
         pool.install(|| {
             let chunk_results: Result<Vec<Vec<u32>>, String> = self
@@ -163,7 +164,8 @@ impl PreTokenizedString {
         }
 
         let pool = bpe_pool();
-        let chunk_size = (self.splits.len() + pool.current_num_threads() - 1) / pool.current_num_threads();
+        let chunk_size =
+            (self.splits.len() + pool.current_num_threads() - 1) / pool.current_num_threads();
 
         pool.install(|| {
             let chunk_results: Result<Vec<Vec<u32>>, String> = self
@@ -344,9 +346,7 @@ mod tests {
     #[test]
     fn tokenize_propagates_error() {
         let pts = PreTokenizedString::from_text("x");
-        let err = pts
-            .tokenize(|_, _out| Err("boom".to_string()))
-            .unwrap_err();
+        let err = pts.tokenize(|_, _out| Err("boom".to_string())).unwrap_err();
         assert_eq!(err, "boom");
     }
 }

--- a/src/pre_tokenizers/split.rs
+++ b/src/pre_tokenizers/split.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "pcre2")]
 use std::cell::RefCell;
+#[cfg(feature = "pcre2")]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use fancy_regex::Regex;
@@ -11,10 +13,12 @@ use crate::pre_tokenized::{PreTokenizedString, Split as PtSplit};
 use super::Error;
 
 // Thread-local cache of previous Split results for incremental re-use.
+#[cfg(feature = "pcre2")]
 thread_local! {
     static SPLIT_CACHE: RefCell<SplitCache> = RefCell::new(SplitCache::default());
 }
 
+#[cfg(feature = "pcre2")]
 struct SplitCache {
     /// Identity of the Split pre-tokenizer that populated this cache.
     /// Prevents cross-model contamination when different models share a thread.
@@ -23,6 +27,7 @@ struct SplitCache {
     prev_matches: Vec<(usize, usize)>,
 }
 
+#[cfg(feature = "pcre2")]
 impl Default for SplitCache {
     fn default() -> Self {
         Self {
@@ -34,22 +39,28 @@ impl Default for SplitCache {
 }
 
 /// Minimum shared prefix length (bytes) before incremental re-use kicks in.
+#[cfg(feature = "pcre2")]
 const INCREMENTAL_MIN_PREFIX: usize = 4096;
 
 /// Wrapper around a JIT-compiled PCRE2 regex for the Llama-3 pattern.
+#[cfg(feature = "pcre2")]
 struct Pcre2Regex(pcre2::bytes::Regex);
 
 // Safety: PCRE2 JIT-compiled regexes are thread-safe for matching.
 // Each thread uses independent match data internally via pcre2 crate.
+#[cfg(feature = "pcre2")]
 unsafe impl Send for Pcre2Regex {}
+#[cfg(feature = "pcre2")]
 unsafe impl Sync for Pcre2Regex {}
 
+#[cfg(feature = "pcre2")]
 impl std::fmt::Debug for Pcre2Regex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Pcre2Regex(...)")
     }
 }
 
+#[cfg(feature = "pcre2")]
 impl Clone for Pcre2Regex {
     fn clone(&self) -> Self {
         // Re-compile for independent match state.
@@ -137,6 +148,7 @@ struct SplitRaw {
 }
 
 /// Monotonic counter for unique Split instance IDs.
+#[cfg(feature = "pcre2")]
 static SPLIT_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 
 /// A compiled Split pre-tokenizer.
@@ -151,6 +163,7 @@ static SPLIT_ID_COUNTER: AtomicUsize = AtomicUsize::new(1);
 pub struct Split {
     /// Unique identity for cache invalidation across different Split instances.
     #[serde(skip)]
+    #[cfg(feature = "pcre2")]
     id: usize,
     /// Pre-compiled regex copies for parallel matching. Index 0 is the
     /// "primary" used for sequential matching; the rest are independent
@@ -160,12 +173,14 @@ pub struct Split {
     invert: bool,
     /// PCRE2 JIT-compiled regex copies for parallel matching (one per thread).
     /// Compiled opportunistically for all patterns; `None` only if PCRE2
-    /// cannot handle the pattern syntax.
+    /// cannot handle the pattern syntax or the feature is disabled.
+    #[cfg(feature = "pcre2")]
     pcre2_regexes: Option<Vec<Pcre2Regex>>,
 }
 
 /// Compile PCRE2 JIT regexes from `source`, returning `None` if PCRE2 cannot
 /// handle the pattern (e.g. unsupported syntax).
+#[cfg(feature = "pcre2")]
 fn try_compile_pcre2_regexes(source: &str, n: usize) -> Option<Vec<Pcre2Regex>> {
     let mut regexes = Vec::with_capacity(n);
     for _ in 0..n {
@@ -179,7 +194,6 @@ fn try_compile_pcre2_regexes(source: &str, n: usize) -> Option<Vec<Pcre2Regex>> 
     }
     Some(regexes)
 }
-
 
 /// Compile `n` independent copies of a regex from `source`.
 fn compile_regexes(source: &str, n: usize) -> Result<Vec<Regex>, Error> {
@@ -195,14 +209,15 @@ impl TryFrom<SplitRaw> for Split {
 
     fn try_from(raw: SplitRaw) -> Result<Self, Error> {
         let source = raw.pattern.source();
-        let pcre2_regexes = try_compile_pcre2_regexes(&source, max_parallel());
         let regexes = compile_regexes(&source, max_parallel())?;
         Ok(Self {
+            #[cfg(feature = "pcre2")]
             id: SPLIT_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
             regexes,
             behavior: raw.behavior,
             invert: raw.invert,
-            pcre2_regexes,
+            #[cfg(feature = "pcre2")]
+            pcre2_regexes: try_compile_pcre2_regexes(&source, max_parallel()),
         })
     }
 }
@@ -217,13 +232,14 @@ impl Split {
         let source = pattern.source();
         let regexes = compile_regexes(&source, max_parallel())?;
         let behavior: SplitBehavior = serde_json::from_value(Value::String(behavior.to_string()))?;
-        let pcre2_regexes = try_compile_pcre2_regexes(&source, max_parallel());
         Ok(Self {
+            #[cfg(feature = "pcre2")]
             id: SPLIT_ID_COUNTER.fetch_add(1, Ordering::Relaxed),
             regexes,
             behavior,
             invert,
-            pcre2_regexes,
+            #[cfg(feature = "pcre2")]
+            pcre2_regexes: try_compile_pcre2_regexes(&source, max_parallel()),
         })
     }
 
@@ -240,6 +256,7 @@ impl Split {
         // step). Multi-split inputs (e.g. from an earlier Sequence step)
         // go through the generic per-split path which still uses PCRE2 via
         // find_segments.
+        #[cfg(feature = "pcre2")]
         if self.pcre2_regexes.is_some()
             && self.behavior == SplitBehavior::Isolated
             && !self.invert
@@ -284,6 +301,7 @@ impl Split {
     /// Uses PCRE2 JIT-compiled regex with parallel matching and incremental
     /// caching. Since behavior is Isolated, every match and every gap between
     /// matches becomes its own split.
+    #[cfg(feature = "pcre2")]
     fn pre_tokenize_pcre2_isolated(&self, pts: &mut PreTokenizedString) -> Result<(), Error> {
         let buffer = pts.buffer();
         let bytes = buffer.as_bytes();
@@ -328,12 +346,10 @@ impl Split {
         // Run PCRE2 on the portion after the reusable prefix.
         let suffix = &text[restart_pos..];
         if suffix.len() >= MIN_CHUNK_SIZE * 2 {
-            let suffix_matches =
-                self.find_matches_pcre2_parallel(suffix, base + restart_pos)?;
+            let suffix_matches = self.find_matches_pcre2_parallel(suffix, base + restart_pos)?;
             matches.extend(suffix_matches);
         } else if !suffix.is_empty() {
-            let suffix_matches =
-                find_matches_pcre2(suffix, base + restart_pos, &pcre2[0])?;
+            let suffix_matches = find_matches_pcre2(suffix, base + restart_pos, &pcre2[0])?;
             matches.extend(suffix_matches);
         }
 
@@ -342,13 +358,22 @@ impl Split {
         let mut prev = base;
         for &(s, e) in &matches {
             if s > prev {
-                new_splits.push(PtSplit { range: prev..s, token_id: None });
+                new_splits.push(PtSplit {
+                    range: prev..s,
+                    token_id: None,
+                });
             }
-            new_splits.push(PtSplit { range: s..e, token_id: None });
+            new_splits.push(PtSplit {
+                range: s..e,
+                token_id: None,
+            });
             prev = e;
         }
         if prev < base + text.len() {
-            new_splits.push(PtSplit { range: prev..(base + text.len()), token_id: None });
+            new_splits.push(PtSplit {
+                range: prev..(base + text.len()),
+                token_id: None,
+            });
         }
 
         // Update the cache for next call: move matches (no clone).
@@ -375,6 +400,7 @@ impl Split {
     /// starting near a boundary are still found in full.  Only matches whose
     /// start falls within a thread's authority zone are kept; the rest are
     /// discarded (the adjacent chunk owns them).
+    #[cfg(feature = "pcre2")]
     fn find_matches_pcre2_parallel(
         &self,
         text: &str,
@@ -414,10 +440,7 @@ impl Split {
                 let auth_end = auth[i + 1];
                 // Extend past authority zone so cross-boundary matches are
                 // found in full.
-                let chunk_end = snap_char_ceil(
-                    text,
-                    (auth_end + CHUNK_OVERLAP).min(text.len()),
-                );
+                let chunk_end = snap_char_ceil(text, (auth_end + CHUNK_OVERLAP).min(text.len()));
                 let chunk = &text[auth_start..chunk_end];
                 let all = find_matches_pcre2(chunk, base + auth_start, &pcre2[i])?;
                 // Keep only matches whose start is in our authority zone.
@@ -473,6 +496,7 @@ impl Split {
     /// `(start, end, is_match)` segments.
     fn find_segments(&self, input: &str) -> Result<Vec<(usize, usize, bool)>, Error> {
         // Prefer PCRE2 JIT when available.
+        #[cfg(feature = "pcre2")]
         if let Some(pcre2) = &self.pcre2_regexes {
             let matches = if input.len() >= MIN_CHUNK_SIZE * 2 && pcre2.len() >= 2 {
                 self.find_matches_pcre2_parallel(input, 0)?
@@ -558,10 +582,7 @@ impl Split {
             .map(|i| {
                 let auth_start = auth[i];
                 let auth_end = auth[i + 1];
-                let chunk_end = snap_char_ceil(
-                    input,
-                    (auth_end + CHUNK_OVERLAP).min(input.len()),
-                );
+                let chunk_end = snap_char_ceil(input, (auth_end + CHUNK_OVERLAP).min(input.len()));
                 let regex = &regexes[i];
                 let chunk = &input[auth_start..chunk_end];
                 let mut matches = Vec::new();
@@ -755,8 +776,7 @@ fn merge_chunk_matches(
                         Some((ms, me)) => {
                             // Check convergence with remaining parallel matches.
                             let limit = remaining.len().min(64);
-                            if let Some(j) =
-                                remaining[..limit].iter().position(|&m| m == (ms, me))
+                            if let Some(j) = remaining[..limit].iter().position(|&m| m == (ms, me))
                             {
                                 // Converged — resume from this point in flat.
                                 idx += j;
@@ -806,6 +826,7 @@ fn matches_to_segments(
 /// Find the length of the common prefix between two byte slices.
 ///
 /// Compares 8 bytes at a time for speed on large inputs.
+#[cfg(feature = "pcre2")]
 fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
     let min_len = a.len().min(b.len());
     let chunks = min_len / 8;
@@ -828,6 +849,7 @@ fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
 }
 
 /// Find all pattern matches using PCRE2 JIT.
+#[cfg(feature = "pcre2")]
 fn find_matches_pcre2(
     input: &str,
     base: usize,
@@ -1059,12 +1081,7 @@ mod tests {
 
     #[test]
     fn llama3_full_coverage() {
-        let s = Split::from_config(
-            &json!({"Regex": LLAMA3_PATTERN}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": LLAMA3_PATTERN}), "Isolated", false).unwrap();
         let inputs = [
             "Hello, world!",
             "fn main() { println!(\"hello\"); }",
@@ -1090,12 +1107,7 @@ mod tests {
 
     #[test]
     fn llama3_digits_are_individual() {
-        let s = Split::from_config(
-            &json!({"Regex": LLAMA3_PATTERN}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": LLAMA3_PATTERN}), "Isolated", false).unwrap();
         // \p{N} matches one digit at a time, not runs.
         let result = s.split("12345").unwrap();
         assert_eq!(result, vec!["1", "2", "3", "4", "5"]);
@@ -1103,12 +1115,7 @@ mod tests {
 
     #[test]
     fn gpt2_contractions() {
-        let s = Split::from_config(
-            &json!({"Regex": GPT2_PATTERN}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": GPT2_PATTERN}), "Isolated", false).unwrap();
         let input = "I'm don't we're they've I'll he'd";
         let result = s.split(input).unwrap();
         assert!(result.contains(&"'m"));
@@ -1122,12 +1129,7 @@ mod tests {
 
     #[test]
     fn gpt2_full_coverage() {
-        let s = Split::from_config(
-            &json!({"Regex": GPT2_PATTERN}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": GPT2_PATTERN}), "Isolated", false).unwrap();
         let inputs = [
             "Hello, world!",
             "  multiple   spaces  ",
@@ -1145,48 +1147,28 @@ mod tests {
 
     #[test]
     fn digits_only_leaves_gaps() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\d+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\d+"}), "Isolated", false).unwrap();
         let result = s.split("abc123def456ghi").unwrap();
         assert_eq!(result, vec!["abc", "123", "def", "456", "ghi"]);
     }
 
     #[test]
     fn letters_only_with_gaps() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\p{L}+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\p{L}+"}), "Isolated", false).unwrap();
         let result = s.split("hello---world...test").unwrap();
         assert_eq!(result, vec!["hello", "---", "world", "...", "test"]);
     }
 
     #[test]
     fn alternation_with_gaps() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\p{L}+|\\d+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\p{L}+|\\d+"}), "Isolated", false).unwrap();
         let result = s.split("abc@123#def!456").unwrap();
         assert_eq!(result, vec!["abc", "@", "123", "#", "def", "!", "456"]);
     }
 
     #[test]
     fn gaps_with_removed_behavior() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\d+"}),
-            "Removed",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\d+"}), "Removed", false).unwrap();
         // Matches (digits) are removed; only gaps remain.
         let result = s.split("abc123def456ghi").unwrap();
         assert_eq!(result, vec!["abc", "def", "ghi"]);
@@ -1194,24 +1176,14 @@ mod tests {
 
     #[test]
     fn gaps_merged_with_next() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\s+"}),
-            "MergedWithNext",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\s+"}), "MergedWithNext", false).unwrap();
         let result = s.split("hello world test").unwrap();
         assert_eq!(result, vec!["hello", " world", " test"]);
     }
 
     #[test]
     fn contiguous_adjacent_single_matches() {
-        let s = Split::from_config(
-            &json!({"Regex": "[a-c]"}),
-            "Contiguous",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "[a-c]"}), "Contiguous", false).unwrap();
         // Each letter is a separate match; Contiguous merges adjacent matches.
         let result = s.split("abcxabc").unwrap();
         assert_eq!(result, vec!["abc", "x", "abc"]);
@@ -1221,12 +1193,7 @@ mod tests {
 
     #[test]
     fn titlecase_letter_pattern() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\p{Lt}"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\p{Lt}"}), "Isolated", false).unwrap();
         // U+01C5 (Dž), U+01C8 (Lj), U+01CB (Nj) are titlecase letters.
         let input = "a\u{01c5}b\u{01c8}c\u{01cb}d";
         let result = s.split(input).unwrap();
@@ -1238,12 +1205,8 @@ mod tests {
 
     #[test]
     fn camelcase_pattern() {
-        let s = Split::from_config(
-            &json!({"Regex": "[\\p{Lu}][\\p{Ll}]*"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "[\\p{Lu}][\\p{Ll}]*"}), "Isolated", false)
+            .unwrap();
         let result = s.split("CamelCaseHTTPServer").unwrap();
         assert_eq!(result.join(""), "CamelCaseHTTPServer");
         assert!(result.contains(&"Camel"));
@@ -1272,12 +1235,7 @@ mod tests {
 
     #[test]
     fn pattern_matches_nothing_in_input() {
-        let s = Split::from_config(
-            &json!({"Regex": "ZZZZZ"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "ZZZZZ"}), "Isolated", false).unwrap();
         // No matches → entire input is one gap segment.
         let result = s.split("hello world").unwrap();
         assert_eq!(result, vec!["hello world"]);
@@ -1285,12 +1243,7 @@ mod tests {
 
     #[test]
     fn pattern_single_char_matches() {
-        let s = Split::from_config(
-            &json!({"Regex": "."}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "."}), "Isolated", false).unwrap();
         // Every char is a match, no gaps at all.
         let result = s.split("abc").unwrap();
         assert_eq!(result, vec!["a", "b", "c"]);
@@ -1300,12 +1253,7 @@ mod tests {
 
     #[test]
     fn invert_removes_non_matching() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\p{L}+"}),
-            "Removed",
-            true,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\p{L}+"}), "Removed", true).unwrap();
         // Invert flips match/gap, Removed drops the new "matches" (which
         // are the original gaps). Only letter runs survive.
         let result = s.split("hello 123 world 456").unwrap();
@@ -1314,12 +1262,7 @@ mod tests {
 
     #[test]
     fn invert_contiguous_vowels() {
-        let s = Split::from_config(
-            &json!({"Regex": "[aeiou]+"}),
-            "Contiguous",
-            true,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "[aeiou]+"}), "Contiguous", true).unwrap();
         // Inverted: vowels become gaps, consonant runs become matches.
         // Contiguous merges adjacent same-type segments.
         let result = s.split("hello").unwrap();
@@ -1342,18 +1285,8 @@ mod tests {
     #[test]
     fn sequential_two_splits() {
         // First: remove whitespace.  Then: isolate digits.
-        let s1 = Split::from_config(
-            &json!({"Regex": "\\s+"}),
-            "Removed",
-            false,
-        )
-        .unwrap();
-        let s2 = Split::from_config(
-            &json!({"Regex": "\\d+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s1 = Split::from_config(&json!({"Regex": "\\s+"}), "Removed", false).unwrap();
+        let s2 = Split::from_config(&json!({"Regex": "\\d+"}), "Isolated", false).unwrap();
 
         let mut pts = PreTokenizedString::from_text("hello 123world 456test");
         s1.pre_tokenize(&mut pts).unwrap();
@@ -1368,50 +1301,36 @@ mod tests {
     #[test]
     fn sequential_three_splits() {
         // Whitespace → digits → uppercase letters.
-        let s1 = Split::from_config(
-            &json!({"Regex": "\\s+"}),
-            "Removed",
-            false,
-        )
-        .unwrap();
-        let s2 = Split::from_config(
-            &json!({"Regex": "\\d+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
-        let s3 = Split::from_config(
-            &json!({"Regex": "[\\p{Lu}]+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let s1 = Split::from_config(&json!({"Regex": "\\s+"}), "Removed", false).unwrap();
+        let s2 = Split::from_config(&json!({"Regex": "\\d+"}), "Isolated", false).unwrap();
+        let s3 = Split::from_config(&json!({"Regex": "[\\p{Lu}]+"}), "Isolated", false).unwrap();
 
         let mut pts = PreTokenizedString::from_text("helloWORLD 123ABCdef");
         s1.pre_tokenize(&mut pts).unwrap();
         s2.pre_tokenize(&mut pts).unwrap();
         s3.pre_tokenize(&mut pts).unwrap();
 
-        assert_eq!(
-            pts_texts(&pts),
-            vec!["hello", "WORLD", "123", "ABC", "def"],
-        );
+        assert_eq!(pts_texts(&pts), vec!["hello", "WORLD", "123", "ABC", "def"],);
     }
 
     #[test]
     fn sequential_preserves_added_tokens() {
-        let s = Split::from_config(
-            &json!({"Regex": "\\s+"}),
-            "Removed",
-            false,
-        )
-        .unwrap();
+        let s = Split::from_config(&json!({"Regex": "\\s+"}), "Removed", false).unwrap();
 
         let buffer = "hello world".to_string();
         let splits = vec![
-            PtSplit { range: 0..5, token_id: None },
-            PtSplit { range: 5..5, token_id: Some(42) },
-            PtSplit { range: 5..11, token_id: None },
+            PtSplit {
+                range: 0..5,
+                token_id: None,
+            },
+            PtSplit {
+                range: 5..5,
+                token_id: Some(42),
+            },
+            PtSplit {
+                range: 5..11,
+                token_id: None,
+            },
         ];
         let mut pts = PreTokenizedString::new(buffer, splits);
         s.pre_tokenize(&mut pts).unwrap();
@@ -1423,18 +1342,8 @@ mod tests {
     #[test]
     fn sequential_mixed_behaviors() {
         // First split: isolate punctuation. Second split: merge whitespace with next.
-        let s1 = Split::from_config(
-            &json!({"Regex": "[,.!?]+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
-        let s2 = Split::from_config(
-            &json!({"Regex": "\\s+"}),
-            "MergedWithNext",
-            false,
-        )
-        .unwrap();
+        let s1 = Split::from_config(&json!({"Regex": "[,.!?]+"}), "Isolated", false).unwrap();
+        let s2 = Split::from_config(&json!({"Regex": "\\s+"}), "MergedWithNext", false).unwrap();
 
         let mut pts = PreTokenizedString::from_text("hello, world! test");
         s1.pre_tokenize(&mut pts).unwrap();
@@ -1491,11 +1400,7 @@ mod tests {
         // A single match spans three chunks.
         // Chunk 0: truncated (0, 10). Chunk 1: ghost (8, 20). Chunk 2: ghost (18, 30).
         // True match: (0, 30). Then a normal match at (35, 40).
-        let chunks = vec![
-            vec![(0, 10)],
-            vec![(8, 20)],
-            vec![(18, 30), (35, 40)],
-        ];
+        let chunks = vec![vec![(0, 10)], vec![(8, 20)], vec![(18, 30), (35, 40)]];
         let full = [(0, 30), (35, 40)];
         let result = merge_with_oracle(chunks, &full);
         assert_eq!(result, vec![(0, 30), (35, 40)]);
@@ -1517,6 +1422,49 @@ mod tests {
         let full = [(0, 10), (15, 20)];
         let result = merge_with_oracle(chunks, &full);
         assert_eq!(result, vec![(0, 10), (15, 20)]);
+    }
+
+    // ── pcre2 feature gate ────────────────────────────────────────────
+
+    /// When the `pcre2` feature is on, the Split struct should have a
+    /// `pcre2_regexes` field that is `Some` for compilable patterns.
+    #[test]
+    #[cfg(feature = "pcre2")]
+    fn pcre2_regexes_populated_when_feature_on() {
+        let s = Split::from_config(&json!({"Regex": "\\p{L}+"}), "Isolated", false).unwrap();
+        assert!(
+            s.pcre2_regexes.is_some(),
+            "pcre2_regexes should be Some when pcre2 feature is enabled",
+        );
+    }
+
+    /// When the `pcre2` feature is off, the fancy-regex fallback must
+    /// produce identical results to the pcre2 path.  This test uses
+    /// a complex real-world pattern (Llama-3) on non-trivial Unicode
+    /// input to verify correctness of the fallback.
+    #[test]
+    #[cfg(not(feature = "pcre2"))]
+    fn fancy_regex_fallback_matches_expected_output() {
+        let s = Split::from_config(&json!({"Regex": LLAMA3_PATTERN}), "Isolated", false).unwrap();
+        // Verify on a mix of scripts, emoji, whitespace, digits, and
+        // contractions -- the same inputs that the pcre2 path handles.
+        let inputs = [
+            "Hello, world!",
+            "café résumé naïve",
+            "你好世界 こんにちは 안녕하세요",
+            "\u{1f680}\u{1f4a1}\u{2728} emoji text \u{1f389}",
+            "CamelCase snake_case kebab-case",
+            "I'm don't we're they've I'll he'd",
+            "100,000.50 + 3.14e-10 = ?",
+        ];
+        for &input in &inputs {
+            let pieces = s.split(input).unwrap();
+            assert_eq!(
+                pieces.join(""),
+                input,
+                "fancy-regex fallback lost bytes on {input:?}: pieces={pieces:?}",
+            );
+        }
     }
 
     // ── integration: long match crossing parallel chunk boundary ─────
@@ -1550,12 +1498,8 @@ mod tests {
         }
         assert!(input.len() >= 2 * chunk, "input must trigger parallel path");
 
-        let split = Split::from_config(
-            &serde_json::json!({"Regex": "[a-z]+"}),
-            "Isolated",
-            false,
-        )
-        .unwrap();
+        let split =
+            Split::from_config(&serde_json::json!({"Regex": "[a-z]+"}), "Isolated", false).unwrap();
 
         let pieces = split.split(&input).unwrap();
         // There should be exactly 3 pieces: digits, long 'a' run, digits.
@@ -1569,11 +1513,16 @@ mod tests {
             long_piece.len(),
         );
         // Also verify via byte offsets
-        let a_pieces: Vec<&str> = pieces.iter().copied().filter(|p| p.starts_with('a')).collect();
-        assert_eq!(a_pieces.len(), 1, "should be exactly one 'a' piece, got {a_pieces:?}");
+        let a_pieces: Vec<&str> = pieces
+            .iter()
+            .copied()
+            .filter(|p| p.starts_with('a'))
+            .collect();
         assert_eq!(
-            &input[match_start..match_end],
-            *long_piece,
+            a_pieces.len(),
+            1,
+            "should be exactly one 'a' piece, got {a_pieces:?}"
         );
+        assert_eq!(&input[match_start..match_end], *long_piece,);
     }
 }


### PR DESCRIPTION
Add [features] section to Cargo.toml with pcre2 as an optinal and default feature. 

- Gate all pcre2-related code in split.rs behind `#[cfg(feature = pcre2)]` so consumers can opt out with `default-features = false`. 

- Add feature-gated tests for both pcre2-on and fallback paths. 

- Document the feature flag in README.md and add CONTRIBUTING.md with build/test instructions.


Related Dynamo CI failure - https://github.com/ai-dynamo/dynamo/actions/runs/23101799392/job/67103786703

This will allow disabling strict pcre2  (`libpcre2-dev`) dependency -

```
=================================== FAILURES ===================================
_______________________ test_no_bundled_shared_libraries _______________________
tests/basic/test_wheel_contents.py:34: in test_no_bundled_shared_libraries
    assert (
E   AssertionError: Unexpected shared libraries bundled in ai-dynamo-runtime:
E       ai_dynamo_runtime.libs/libpcre2-8-516f4c9d.so.0
E   assert not ['ai_dynamo_runtime.libs/libpcre2-8-516f4c9d.so.0']
        bundled_libs = ['ai_dynamo_runtime.libs/libpcre2-8-516f4c9d.so.0']
        installed_files = [PackagePath('ai_dynamo_runtime-1.0.0.dist-info/INSTALLER'), PackagePath('ai_dynamo_runtime-1.0.0.dist-info/METADATA')...Path('ai_dynamo_runtime-1.0.0.dist-info/WHEEL'), PackagePath('ai_dynamo_runtime-1.0.0.dist-info/direct_url.json'), ...]
```