### PR TITLE
Bugfix/ignore merges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,19 +700,28 @@ mod tests {
         let text = " имущества";
         let hf_ids = hf.encode(text, false).unwrap().get_ids().to_vec();
         let our_ids = ours.encode(text).unwrap();
-        assert_eq!(our_ids, hf_ids,
-            "ignore_merges mismatch on {text:?}: ours={our_ids:?} hf={hf_ids:?}");
+        assert_eq!(
+            our_ids, hf_ids,
+            "ignore_merges mismatch on {text:?}: ours={our_ids:?} hf={hf_ids:?}"
+        );
 
         // Also test with random-token-decoded text (the benchmark pattern).
         let vocab_size = hf.get_vocab_size(false) as u64;
         let random_ids: Vec<u32> = (0..5000)
-            .map(|i| ((i as u64).wrapping_mul(6364136223846793005).wrapping_add(1) % vocab_size) as u32)
+            .map(|i| {
+                ((i as u64).wrapping_mul(6364136223846793005).wrapping_add(1) % vocab_size) as u32
+            })
             .collect();
         let text = hf.decode(&random_ids, true).unwrap();
         let hf_enc = hf.encode(text.as_str(), false).unwrap().get_ids().to_vec();
         let our_enc = ours.encode(&text).unwrap();
-        assert_eq!(our_enc, hf_enc,
-            "ignore_merges random-decode mismatch: {} vs {} tokens", our_enc.len(), hf_enc.len());
+        assert_eq!(
+            our_enc,
+            hf_enc,
+            "ignore_merges random-decode mismatch: {} vs {} tokens",
+            our_enc.len(),
+            hf_enc.len()
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,6 +689,33 @@ mod tests {
     }
 
     #[test]
+    fn ignore_merges_glm47() {
+        let model = "zai-org/GLM-4.7";
+        let hf = tokenizers::Tokenizer::from_pretrained(model, None).unwrap();
+        let ours = Tokenizer::from_model(model).unwrap();
+
+        // " имущества" is a single token (140507) in GLM-4.7 vocab.
+        // BPE merging alone produces 3 tokens — ignore_merges must
+        // short-circuit to the vocab entry.
+        let text = " имущества";
+        let hf_ids = hf.encode(text, false).unwrap().get_ids().to_vec();
+        let our_ids = ours.encode(text).unwrap();
+        assert_eq!(our_ids, hf_ids,
+            "ignore_merges mismatch on {text:?}: ours={our_ids:?} hf={hf_ids:?}");
+
+        // Also test with random-token-decoded text (the benchmark pattern).
+        let vocab_size = hf.get_vocab_size(false) as u64;
+        let random_ids: Vec<u32> = (0..5000)
+            .map(|i| ((i as u64).wrapping_mul(6364136223846793005).wrapping_add(1) % vocab_size) as u32)
+            .collect();
+        let text = hf.decode(&random_ids, true).unwrap();
+        let hf_enc = hf.encode(text.as_str(), false).unwrap().get_ids().to_vec();
+        let our_enc = ours.encode(&text).unwrap();
+        assert_eq!(our_enc, hf_enc,
+            "ignore_merges random-decode mismatch: {} vs {} tokens", our_enc.len(), hf_enc.len());
+    }
+
+    #[test]
     fn correctness_qwen3() {
         let f = compare_encode_decode("Qwen/Qwen3-0.6B", CORPUS);
         assert!(f.is_empty(), "Qwen/Qwen3-0.6B:\n{}", f.join("\n"));

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -363,6 +363,8 @@ struct RawBpe {
     #[serde(default)]
     #[allow(dead_code)]
     byte_fallback: bool,
+    #[serde(default)]
+    ignore_merges: bool,
 }
 
 /// Monotonic counter for unique Bpe instance IDs.
@@ -591,6 +593,7 @@ pub struct Bpe {
     ranked_merge_map: RankedMergeMap,
     byte_pair_initial: Vec<(u32, u32)>,
     merge_adj: MergeAdjacency,
+    ignore_merges: bool,
 }
 
 impl TryFrom<RawBpe> for Bpe {
@@ -598,7 +601,9 @@ impl TryFrom<RawBpe> for Bpe {
 
     fn try_from(raw: RawBpe) -> Result<Self> {
         let merge_map = parse_merges(&raw.vocab, &raw.merges)?;
-        Self::new(&raw.vocab, merge_map)
+        let mut bpe = Self::new(&raw.vocab, merge_map)?;
+        bpe.ignore_merges = raw.ignore_merges;
+        Ok(bpe)
     }
 }
 
@@ -802,6 +807,7 @@ impl Bpe {
             ranked_merge_map,
             byte_pair_initial,
             merge_adj,
+            ignore_merges: false,
         })
     }
 
@@ -1118,6 +1124,17 @@ impl Bpe {
             return Ok(());
         }
 
+        if self.ignore_merges {
+            let mut encoded = String::with_capacity(raw_input.len());
+            for &byte in raw_input.as_bytes() {
+                encoded.push(BYTE_TO_CHAR[byte as usize]);
+            }
+            if let Some(&id) = self.token_to_id.get(encoded.as_str()) {
+                out.push(id);
+                return Ok(());
+            }
+        }
+
         self.merge_all_raw_into(raw_input, out)?;
 
         let ids = &out[start..];
@@ -1168,6 +1185,18 @@ impl Bpe {
                         continue;
                     }
 
+                    if self.ignore_merges {
+                        let mut encoded = String::with_capacity(text.len());
+                        for &byte in text.as_bytes() {
+                            encoded.push(BYTE_TO_CHAR[byte as usize]);
+                        }
+                        if let Some(&id) = self.token_to_id.get(encoded.as_str()) {
+                            out.push(id);
+                            cache.insert(text, &out[start..]);
+                            continue;
+                        }
+                    }
+
                     self.merge_all_raw_into(text, out)?;
 
                     cache.insert(text, &out[start..]);
@@ -1210,6 +1239,7 @@ impl Clone for Bpe {
             ranked_merge_map: self.ranked_merge_map.clone(),
             byte_pair_initial: self.byte_pair_initial.clone(),
             merge_adj: self.merge_adj.clone(),
+            ignore_merges: self.ignore_merges,
         }
     }
 }
@@ -1230,6 +1260,7 @@ impl PartialEq for Bpe {
             && self.unmerge_map == other.unmerge_map
             && self.next_prefix_map == other.next_prefix_map
             && self.token_lens == other.token_lens
+            && self.ignore_merges == other.ignore_merges
     }
 }
 


### PR DESCRIPTION
Parse ignore_merges flag from tokenizer.json BPE config.
When true, check if the entire pre-tokenizer chunk exists as a single vocab entry before running BPE - matching HuggingFace's behavior