### PR TITLE
fix: skip PCRE2 for patterns with character class intersection (&&)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,6 +549,7 @@ mod tests {
         "Qwen/Qwen3-Coder-480B-A35B-Instruct",
         "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
         "nvidia/Qwen3-Nemotron-235B-A22B-GenRM",
+        "hoangquan456/Kimi-K2.5",
     ];
 
     /// Verify that `TokenizerConfig` and `TokenizerJson` deserialize
@@ -898,6 +899,12 @@ mod tests {
             "nvidia/Qwen3-Nemotron-235B-A22B-GenRM:\n{}",
             f.join("\n")
         );
+    }
+
+    #[test]
+    fn correctness_kimi_k2_5() {
+        let f = compare_encode_decode("hoangquan456/Kimi-K2.5", CORPUS);
+        assert!(f.is_empty(), "hoangquan456/Kimi-K2.5:\n{}", f.join("\n"));
     }
 
     // ── Cache consistency ────────────────────────────────────────────

--- a/src/pre_tokenizers/split.rs
+++ b/src/pre_tokenizers/split.rs
@@ -158,6 +158,9 @@ pub struct Split {
 /// Compile PCRE2 JIT regexes from `source`, returning `None` if PCRE2 cannot
 /// handle the pattern (e.g. unsupported syntax).
 fn try_compile_pcre2_regexes(source: &str, n: usize) -> Option<Vec<Pcre2Regex>> {
+    if source.contains("&&") {
+        return None;
+    }
     let mut regexes = Vec::with_capacity(n);
     for _ in 0..n {
         let re = pcre2::bytes::RegexBuilder::new()


### PR DESCRIPTION
## Summary

PCRE2 does not support `&&` (character class intersection) inside bracket expressions, but silently accepts the syntax by treating `&` as a literal character. This causes incorrect pre-tokenizer splits for models like Kimi-K2.5 whose pattern contains `&&`.

The fix skips PCRE2 and falls back to fancy-regex whenever the pattern contains `&&`.

## Testing

- All 174 existing tests pass
- Verified on production traffic at DeepInfra comparing fastokens output against the HuggingFace `tokenizers` library
- Also ran the extended test (LongBench + ShareGPT corpus) locally against Kimi-K2.5. Since the model doesn't ship a `tokenizer.json` on HuggingFace, I generated one. If you'd like to reproduce, the converted tokenizer is available at https://huggingface.co/hoangquan456/Kimi-K2.5 