### PR TITLE
tokenizer: expose added token metadata

### DIFF
--- a/src/added_tokens.rs
+++ b/src/added_tokens.rs
@@ -40,6 +40,14 @@ pub enum Segment<'a> {
     Text(&'a str),
 }
 
+/// Public view of one added-token entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AddedTokenInfo<'a> {
+    pub id: u32,
+    pub content: &'a str,
+    pub special: bool,
+}
+
 impl AddedTokens {
     /// Build from the `added_tokens` array in `tokenizer.json`.
     ///
@@ -125,6 +133,20 @@ impl AddedTokens {
     /// Return whether there are no added tokens.
     pub fn is_empty(&self) -> bool {
         self.id_to_content.is_empty()
+    }
+
+    /// Iterate over added-token entries.
+    ///
+    /// The iteration order is unspecified. Callers that need a stable order
+    /// should sort by `id` themselves.
+    pub fn iter(&self) -> impl Iterator<Item = AddedTokenInfo<'_>> {
+        self.id_to_content
+            .iter()
+            .map(|(&id, content)| AddedTokenInfo {
+                id,
+                content: content.as_str(),
+                special: self.special_ids.contains(&id),
+            })
     }
 
     /// Split `input` into segments: spans matching added tokens and spans of
@@ -428,6 +450,35 @@ mod tests {
         assert!(at.is_special(1));
         assert!(!at.is_special(2));
         assert!(!at.is_special(99)); // unknown id
+    }
+
+    #[test]
+    fn iter_exposes_id_content_and_special_flag() {
+        let mut special = make_config(1, "<bos>");
+        special.special = true;
+        let plain = make_config(2, "<extra>");
+        let at = AddedTokens::from_configs(&[special, plain])
+            .unwrap()
+            .unwrap();
+
+        let mut entries: Vec<_> = at.iter().collect();
+        entries.sort_by_key(|entry| entry.id);
+
+        assert_eq!(
+            entries,
+            vec![
+                AddedTokenInfo {
+                    id: 1,
+                    content: "<bos>",
+                    special: true,
+                },
+                AddedTokenInfo {
+                    id: 2,
+                    content: "<extra>",
+                    special: false,
+                },
+            ]
+        );
     }
 
     // ── len / is_empty ───────────────────────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use rayon::prelude::*;
 use serde_json::Value;
 
 pub use self::{
-    added_tokens::AddedTokens,
+    added_tokens::{AddedTokenInfo, AddedTokens},
     json_structs::{
         AddedTokenConfig, DecoderConfig, DecoderKind, ModelConfig, ModelKind, NormalizerConfig,
         NormalizerKind, PostProcessorConfig, PostProcessorKind, PreTokenizerConfig,
@@ -212,6 +212,11 @@ impl Tokenizer {
         &self.model
     }
 
+    /// Return the compiled added-token set, if any.
+    pub fn added_tokens(&self) -> Option<&AddedTokens> {
+        self.added_tokens.as_ref()
+    }
+
     /// Return the decoder, if any.
     pub fn decoder(&self) -> Option<&Decoder> {
         self.decoder.as_ref()
@@ -377,6 +382,13 @@ impl Tokenizer {
         let model_size = self.model.vocab_size();
         let added_size = self.added_tokens.as_ref().map_or(0, |at| at.len());
         model_size + added_size
+    }
+
+    /// Return whether this token ID is marked special in the added-token set.
+    pub fn is_special_token(&self, id: u32) -> bool {
+        self.added_tokens
+            .as_ref()
+            .is_some_and(|added_tokens| added_tokens.is_special(id))
     }
 
     // ── Internal helpers ─────────────────────────────────────────────
@@ -626,6 +638,28 @@ mod tests {
             .token_to_id(token_str)
             .expect("reverse lookup should work");
         assert_eq!(id, 0);
+    }
+
+    #[test]
+    fn public_added_token_accessors_expose_added_vocab() {
+        let tok = Tokenizer::from_model("Qwen/Qwen3-0.6B").unwrap();
+        let added_tokens = tok.added_tokens().expect("expected added tokens");
+
+        let think_id = tok.token_to_id("<think>").expect("<think> should exist");
+        assert_eq!(added_tokens.token_to_id("<think>"), Some(think_id));
+        assert_eq!(added_tokens.id_to_token(think_id), Some("<think>"));
+
+        let mut entries: Vec<_> = added_tokens.iter().collect();
+        entries.sort_by_key(|entry| entry.id);
+        let special_entry = entries
+            .iter()
+            .find(|entry| entry.special)
+            .expect("expected at least one special added token");
+        assert!(tok.is_special_token(special_entry.id));
+        assert!(
+            entries.iter().any(|entry| entry.id == think_id && entry.content == "<think>"),
+            "added-token iterator should expose <think>"
+        );
     }
 
     // ── Correctness tests against HuggingFace tokenizers ─────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,9 @@ mod tests {
             .expect("expected at least one special added token");
         assert!(tok.is_special_token(special_entry.id));
         assert!(
-            entries.iter().any(|entry| entry.id == think_id && entry.content == "<think>"),
+            entries
+                .iter()
+                .any(|entry| entry.id == think_id && entry.content == "<think>"),
             "added-token iterator should expose <think>"
         );
     }


### PR DESCRIPTION
Expose public accessors for added-token metadata so downstream callers can inspect the added vocab and special-token flags without reaching into internals.

- add `Tokenizer::added_tokens()` and `Tokenizer::is_special_token()`
- add `AddedTokens::iter()` with `AddedTokenInfo`
- add focused tests for the new accessors
