### PR TITLE
compat: Accept name= kwarg in _ModelStub.save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "fastokens"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fastokens-python"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "fastokens",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 members = [".", "python"]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/Atero-ai/fastokens"
-homepage = "https://github.com/Atero-ai/fastokens"
-documentation = "https://github.com/Atero-ai/fastokens/blob/main/README.md"
+repository = "https://github.com/crusoecloud/fastokens"
+homepage = "https://github.com/crusoecloud/fastokens"
+documentation = "https://github.com/crusoecloud/fastokens/blob/main/README.md"
 
 [package]
 name = "fastokens"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ popular open-weight LLMs, built on top of a high-performance Rust backend.
 
 `fastokens` can be installed from source:
 ```
-git clone https://github.com/atero-ai/fast-tokens
-uv pip install fast-tokens/python
+git clone https://github.com/crusoecloud/fastokens
+uv pip install fastokens/python
 ```
 
 The Python API lives in the `python` directory. To use `fastokens` as a drop-in replacement with

--- a/python/fastokens/_compat.py
+++ b/python/fastokens/_compat.py
@@ -418,9 +418,17 @@ class _ModelStub:
     def __init__(self, shim: _TokenizerShim) -> None:
         self._shim = shim
 
-    def save(self, folder: str, prefix: str | None = None) -> list[str]:
-        name = f"{prefix}-vocab.json" if prefix else "vocab.json"
-        path = Path(folder) / name
+    def save(self, folder: str, name: str | None = None, *, prefix: str | None = None) -> list[str]:
+        # HF transformers fast tokenizer shims (qwen2, bart, bloom, …) call
+        # this with name=<filename_prefix>; the upstream tokenizers .pyi
+        # documents the same arg as ``prefix``. Accept both spellings so the
+        # shim works regardless of which name the caller used.
+        if prefix is not None:
+            if name is not None and name != prefix:
+                raise TypeError("save() got both 'name' and 'prefix'; pass only one")
+            name = prefix
+        filename = f"{name}-vocab.json" if name else "vocab.json"
+        path = Path(folder) / filename
         vocab = self._shim.get_vocab()
         path.write_text(json.dumps(vocab, ensure_ascii=False), encoding="utf-8")
         return [str(path)]

--- a/python/tests/test_patch_transformers.py
+++ b/python/tests/test_patch_transformers.py
@@ -55,3 +55,34 @@ def test_unpatch_restores_backend():
     assert not isinstance(tok._tokenizer, _TokenizerShim), (
         "backend should be original tokenizers.Tokenizer after unpatch"
     )
+
+
+def test_save_pretrained_with_patched_tokenizer(tmp_path):
+    """save_pretrained must work under the patched backend.
+
+    HF fast tokenizers (e.g. Qwen2/Qwen3 family) call
+    ``self._tokenizer.model.save(save_directory, name=filename_prefix)``
+    inside ``save_vocabulary``. Regression for an earlier _ModelStub.save
+    signature that only accepted ``prefix=``.
+    """
+    import fastokens
+
+    fastokens.patch_transformers()
+
+    tok = transformers.AutoTokenizer.from_pretrained(MODEL)
+    tok.save_pretrained(str(tmp_path))
+
+
+def test_model_stub_save_accepts_both_kwargs(tmp_path):
+    """_ModelStub.save must accept both ``name=`` (transformers callsite) and
+    ``prefix=`` (upstream tokenizers .pyi spelling)."""
+    from fastokens._compat import _ModelStub, _TokenizerShim  # noqa: PLC0415
+
+    shim = _TokenizerShim.__new__(_TokenizerShim)
+    shim.get_vocab = lambda: {"a": 1, "b": 2}  # type: ignore[attr-defined]
+    stub = _ModelStub(shim)
+
+    out_name = stub.save(str(tmp_path), name="qwen")
+    out_prefix = stub.save(str(tmp_path), prefix="qwen")
+    out_positional = stub.save(str(tmp_path), "qwen")
+    assert out_name == out_prefix == out_positional


### PR DESCRIPTION
HF transformers' fast tokenizer shims (qwen2/qwen3/bart/bloom/codegen/gpt_neox/ electra/deberta/mvp/herbert/lxmert/layoutlm/markuplm/clip/led/...) call `self._tokenizer.model.save(save_directory, name=filename_prefix)` inside save_vocabulary. The previous stub only accepted prefix=, so any PreTrainedTokenizerFast.save_pretrained() call under fastokens.patch_transformers crashed with TypeError at the first checkpoint save.

Example references - https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/qwen2/tokenization_qwen2_fast.py#L133


Accept both name= and prefix= for forward/backward compatibility (upstream tokenizers .pyi documents prefix; transformers source uses name); raise TypeError if both are passed with conflicting values.

Also update repo URLs (Cargo.toml + README) from the old atero-ai/fast-tokens path to the current crusoecloud/fastokens location, and bump 0.1.2 -> 0.1.3.