### PR TITLE
fix(patch): unpatch_transformers leaves stray classmethod on TokenizersBackend (v5)

### DIFF
--- a/python/fastokens/__init__.py
+++ b/python/fastokens/__init__.py
@@ -121,7 +121,15 @@ def unpatch_transformers() -> None:
     if "TokenizersBackend.from_pretrained" in _originals:
         from transformers.tokenization_utils_tokenizers import TokenizersBackend
 
-        TokenizersBackend.from_pretrained = _originals["TokenizersBackend.from_pretrained"]
+        # `from_pretrained` is inherited from `PreTrainedTokenizerBase`, not
+        # defined on `TokenizersBackend`. The value captured during patch
+        # via attribute access is a bound `method`, not a classmethod
+        # descriptor — assigning it back installs a stray attribute in
+        # `TokenizersBackend.__dict__` that shadows the inherited
+        # classmethod and breaks `cls` polymorphism for subclasses.
+        # Removing our patch attribute restores plain inheritance.
+        if "from_pretrained" in TokenizersBackend.__dict__:
+            del TokenizersBackend.from_pretrained
 
     # v4 path
     if "tokenization_utils_fast" in _originals:


### PR DESCRIPTION
## Summary

`unpatch_transformers()` does not fully restore `transformers` state on the v5 patch path. It leaves a stray `from_pretrained` attribute on `TokenizersBackend.__dict__` that shadows the inherited classmethod from `PreTrainedTokenizerBase`. Subsequent vanilla `AutoTokenizer.from_pretrained(...)` calls take a different code path than they did before the patch+unpatch cycle, producing a different tokenizer for some models (concretely: tokenizers whose `from_pretrained` resolution branches on `cls`, e.g. models declaring a slow `tokenizer_class` in `tokenizer_config.json` that triggers slow→fast conversion).

The v4 path is unaffected — it swaps a module-level name (`transformers.tokenization_utils_fast.TokenizerFast`), which has no descriptor / inheritance semantics.

## Root cause

```python
# patch_transformers (current):
_orig_fp = TokenizersBackend.from_pretrained   # attribute access on inherited classmethod
                                               # → bound `method`, NOT the classmethod descriptor
_originals["TokenizersBackend.from_pretrained"] = _orig_fp
TokenizersBackend.from_pretrained = _patched_from_pretrained

# unpatch_transformers (current — buggy):
TokenizersBackend.from_pretrained = _originals["TokenizersBackend.from_pretrained"]
```

`from_pretrained` is defined on `PreTrainedTokenizerBase`, not on `TokenizersBackend`. Accessing `TokenizersBackend.from_pretrained` walks the MRO, finds the classmethod descriptor on the parent, and returns a method bound to `TokenizersBackend`. Assigning that bound method back via `setattr` installs a new entry in `TokenizersBackend.__dict__` — which from then on shadows the inherited classmethod for every attribute lookup. The shadow is a frozen bound method (`cls` already locked to `TokenizersBackend`), not a descriptor that re-binds per subclass.

This breaks `cls` polymorphism for subclasses: every subsequent `SomeTokenizerClass.from_pretrained(...)` resolves to the bound method with `cls=TokenizersBackend`, instead of re-binding `cls` to `SomeTokenizerClass`.

## Reproduction

```python
import fastokens
from transformers.tokenization_utils_tokenizers import TokenizersBackend

assert "from_pretrained" not in TokenizersBackend.__dict__   # inherited, not owned

fastokens.patch_transformers()
fastokens.unpatch_transformers()

# Bug: stray attribute remains after unpatch
assert "from_pretrained" not in TokenizersBackend.__dict__, \
    f"unpatch leaked: {type(TokenizersBackend.__dict__['from_pretrained']).__name__}"
# AssertionError: unpatch leaked: method
```

Why the leak matters in practice — a minimal classmethod-shadowing demo, no transformers required:

```python
class Parent:
    @classmethod
    def hello(cls):
        return f"hello from {cls.__name__}"

class Child(Parent):     # inherits hello, doesn't define its own
    pass

class Grandchild(Child):
    pass

Grandchild.hello()       # → 'hello from Grandchild'   (classmethod re-binds cls)

# Reproduce the unpatch bug:
saved = Child.hello                       # bound `method`, NOT a classmethod
Child.hello = lambda cls: "wrapped"       # patch
Child.hello = saved                       # "unpatch" (this is what fastokens does)

Grandchild.hello()       # → 'hello from Child'        (cls is now pinned)
```

The bound method captured via attribute access has already had its `cls` resolved at lookup time. Assigning it back doesn't restore the inheritance — it installs a frozen method that overrides it.

## Fix

`del TokenizersBackend.from_pretrained` instead of `setattr` back. Removing the patch attribute restores plain inheritance — `PreTrainedTokenizerBase.from_pretrained` becomes visible again via MRO lookup, with full classmethod-descriptor semantics intact.

```python
# unpatch_transformers (fixed):
if "from_pretrained" in TokenizersBackend.__dict__:
    del TokenizersBackend.from_pretrained
```

Equivalent demo with the bare classes above:

```python
del Child.hello
Grandchild.hello()       # → 'hello from Grandchild'   (correctly re-binds)
```

## Verification

Verified locally on:

- **transformers v5.6.2** (current latest): bug reproduces with `setattr`; `del`-based fix eliminates the stray attribute and restores byte-identical pre/post-cycle behavior across the test suite plus an extended encode-parity probe.
- **transformers v4.57.1** (per fastokens README compat): bug never existed (the v4 path swaps a module-level name, not a class attribute). Fix is a no-op on v4 — the `del`-guarded branch only runs when the v5 patch was installed.

`python/tests/test_patch_transformers.py` continues to pass.

## Why no test in this PR

The repro above is enough to pin the invariant and the fix is one branch. Happy to add a regression test if maintainers prefer — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
