### PR TITLE
fix: count distinct token strings in vocab_size

### DIFF
--- a/src/added_tokens.rs
+++ b/src/added_tokens.rs
@@ -131,6 +131,16 @@ impl AddedTokens {
         self.content_to_id.get(token).copied()
     }
 
+    /// Iterate the distinct content strings of the added tokens.
+    ///
+    /// Unlike [`Self::iter`], which yields one entry per ID, this yields one
+    /// entry per string: two added tokens sharing a content collapse to one.
+    /// That is the granularity a vocabulary count needs, since a vocabulary is a
+    /// token -> ID map and cannot hold the same string twice.
+    pub fn contents(&self) -> impl Iterator<Item = &str> {
+        self.content_to_id.keys().map(String::as_str)
+    }
+
     /// Check if a token ID is a special added token.
     pub fn is_special(&self, id: u32) -> bool {
         self.special_ids.contains(&id)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -927,10 +927,30 @@ impl Tokenizer {
         self.model.token_to_id(token)
     }
 
-    /// Return the vocabulary size (model tokens + added tokens).
+    /// Return the vocabulary size.
+    ///
+    /// A vocabulary is a token -> ID map, so its size is the number of *distinct
+    /// token strings*, which is how HuggingFace `tokenizers` computes it
+    /// (`get_vocab_size(true) == get_vocab(true).len()`). Adding the two counts
+    /// instead overcounts whenever `added_tokens` restates a string that is
+    /// already present, in either of two ways:
+    ///
+    /// - the string is also in `model.vocab` (e.g. a checkpoint that lists
+    ///   BOS/EOS/PAD in both places), or
+    /// - two `added_tokens` entries share a content under different IDs.
+    ///
+    /// Both collapse in a real vocabulary, so both are deduplicated here:
+    /// [`AddedTokens::contents`] yields distinct strings, and the model lookup
+    /// drops the ones the model already provides. Overcounting is not cosmetic —
+    /// callers size embedding tables from this and index every ID below it, so an
+    /// inflated count points at IDs that do not exist.
     pub fn vocab_size(&self) -> usize {
         let model_size = self.model.vocab_size();
-        let added_size = self.added_tokens.as_ref().map_or(0, |at| at.len());
+        let added_size = self.added_tokens.as_ref().map_or(0, |at| {
+            at.contents()
+                .filter(|content| self.model.token_to_id(content).is_none())
+                .count()
+        });
         model_size + added_size
     }
 
@@ -1212,6 +1232,120 @@ mod local_tests {
             err.to_string().contains("match limit"),
             "expected match limit error, got {err}"
         );
+    }
+
+    fn vocab_size_of(model_vocab: Value, added_tokens: Value) -> usize {
+        Tokenizer::from_json(json!({
+            "model": {"type": "BPE", "vocab": model_vocab, "merges": []},
+            "added_tokens": added_tokens,
+        }))
+        .unwrap()
+        .vocab_size()
+    }
+
+    /// Every way `added_tokens` can overlap an existing vocabulary entry.
+    ///
+    /// Expectations are the values HuggingFace `tokenizers` reports from
+    /// `get_vocab_size(true)` for the same `tokenizer.json`, since a vocabulary
+    /// counts distinct token strings.
+    #[test]
+    fn vocab_size_matches_huggingface_across_added_token_overlaps() {
+        // No overlap: every added token is new.
+        assert_eq!(
+            vocab_size_of(
+                json!({"a": 0, "b": 1}),
+                json!([{"id": 2, "content": "<x>"}, {"id": 3, "content": "<y>"}]),
+            ),
+            4
+        );
+
+        // Added tokens restate strings the model already has. Seen in the wild on
+        // checkpoints that list BOS/EOS/PAD in both `model.vocab` and
+        // `added_tokens`.
+        assert_eq!(
+            vocab_size_of(
+                json!({"<bos>": 0, "<eos>": 1, "a": 2, "b": 3}),
+                json!([
+                    {"id": 0, "content": "<bos>", "special": true},
+                    {"id": 1, "content": "<eos>", "special": true},
+                    {"id": 4, "content": "<extra>"}
+                ]),
+            ),
+            5
+        );
+
+        // A gap between the model vocab and the added IDs does not inflate the
+        // count: the size follows the strings, not the highest ID.
+        assert_eq!(
+            vocab_size_of(
+                json!({"a": 0, "b": 1}),
+                json!([{"id": 5, "content": "<far>"}])
+            ),
+            3
+        );
+
+        // A new string at an ID inside the model range still adds one entry.
+        assert_eq!(
+            vocab_size_of(
+                json!({"a": 0, "b": 1, "c": 2}),
+                json!([{"id": 1, "content": "<inside>"}]),
+            ),
+            4
+        );
+    }
+
+    /// Two `added_tokens` entries sharing a content are rejected when the
+    /// matcher is built, so the count never sees that overlap. Recorded because
+    /// it is the reason the vocabulary count only has to deduplicate added
+    /// strings against the *model*, and because HuggingFace `tokenizers` accepts
+    /// such a file (reporting one entry for the shared string) — a separate
+    /// divergence, and the safer direction of the two.
+    #[test]
+    fn duplicate_added_token_contents_are_rejected_at_construction() {
+        // Tokenizer has no Debug impl, so unwrap_err() is unavailable.
+        let result = Tokenizer::from_json(json!({
+            "model": {"type": "BPE", "vocab": {"a": 0, "b": 1}, "merges": []},
+            "added_tokens": [
+                {"id": 2, "content": "<dup>"},
+                {"id": 3, "content": "<dup>"}
+            ],
+        }));
+        let err = match result {
+            Ok(_) => panic!("expected duplicate added-token contents to be rejected"),
+            Err(e) => e,
+        };
+
+        assert!(
+            err.to_string().contains("DuplicatePattern"),
+            "expected a duplicate-pattern error, got {err}"
+        );
+    }
+
+    /// The count must not claim IDs that cannot be resolved, which is the
+    /// property callers rely on when they size an embedding table from it and
+    /// then index every ID below it.
+    #[test]
+    fn vocab_size_only_counts_resolvable_ids() {
+        let tokenizer = Tokenizer::from_json(json!({
+            "model": {
+                "type": "BPE",
+                "vocab": {"<bos>": 0, "<eos>": 1, "a": 2, "b": 3},
+                "merges": []
+            },
+            "added_tokens": [
+                {"id": 0, "content": "<bos>", "special": true},
+                {"id": 1, "content": "<eos>", "special": true},
+                {"id": 4, "content": "<extra>"}
+            ]
+        }))
+        .unwrap();
+
+        for id in 0..tokenizer.vocab_size() as u32 {
+            assert!(
+                tokenizer.id_to_token(id).is_some(),
+                "id {id} is counted but has no token"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`Tokenizer::vocab_size` sums the model vocabulary and the added-token count:

```rust
let model_size = self.model.vocab_size();
let added_size = self.added_tokens.as_ref().map_or(0, |at| at.len());
model_size + added_size
```

That double-counts whenever `added_tokens` restates a string the vocabulary
already holds. A vocabulary is a token -> ID map, so its size is the number of
distinct strings — which is what HuggingFace `tokenizers` reports
(`get_vocab_size(true) == get_vocab(true).len()`).

The overcount is not cosmetic: callers size embedding tables from this and then
index every ID below it, so an inflated count points at IDs that do not exist.

Through `patch_transformers` it surfaces as a hard load failure. DeepSeek-V4's
`tokenizer.json` lists BOS/EOS/PAD in both `model.vocab` and `added_tokens`:

| | vocab size |
|---|---|
| `tokenizers` (and the model's embedding table) | 129280 |
| fastokens | 129283 |

so `transformers` refuses the checkpoint against its own embeddings:

```
UserError: Tokenizer vocabulary size 129283 > # model embeddings 129280
```

`128000` base + `1283` added = `129283`, but ids `0`/`1`/`2`
(`<｜begin▁of▁sentence｜>`, `<｜end▁of▁sentence｜>`, `<｜▁pad▁｜>`) appear in both
places, so the real vocabulary holds `129280`. Encoding is otherwise
byte-identical to the HuggingFace backend, so the only thing standing between
that model and fastokens was this count.

## Deriving the rule rather than patching the symptom

Special-casing that checkpoint's shape would have been wrong — my first attempt
deduplicated added tokens against the *model* only, and that still diverges.
Instead the rule was pinned against HuggingFace across every way `added_tokens`
can overlap an existing entry. `hf` is `tokenizers.get_vocab_size(True)` on the
same `tokenizer.json`:

| case | hf | summed (before) | model-only dedup | this PR |
|---|---|---|---|---|
| no overlap | 4 | 4 | 4 | 4 |
| added restates a model entry | 5 | **7** | 5 | 5 |
| duplicate content, different IDs | 3 | 4 | **4** | 3 |
| ID gap above the model vocab | 3 | 3 | 3 | 3 |
| new content at an ID inside the model range | 4 | 4 | 4 | 4 |

So there are **two** overlap classes to deduplicate, not one: against the model
vocabulary, and among the added tokens themselves.

## Change

`AddedTokens::contents` yields distinct content strings — it walks the existing
`content_to_id` map, so it adds no state and no allocation — and the model
lookup drops strings the model already provides:

```rust
pub fn vocab_size(&self) -> usize {
    let model_size = self.model.vocab_size();
    let added_size = self.added_tokens.as_ref().map_or(0, |at| {
        at.contents()
            .filter(|content| self.model.token_to_id(content).is_none())
            .count()
    });
    model_size + added_size
}
```

One note for reviewers: the duplicate-content row above is currently
**unreachable** through `from_json` — the added-token matcher rejects it with
`DuplicatePatternError`, which is now recorded as a test since it is a
divergence from `tokenizers` in its own right (and the safer direction). So
deduplicating among added tokens is defensive rather than fixing a reachable
bug. I kept it because `vocab_size` sizes embedding tables and is better correct
on its own terms than dependent on a construction-time invariant enforced in
another file. Happy to reduce it to `iter()` if you would rather keep the diff
to the single reachable case — behaviour is identical today.

## Testing

- `vocab_size_matches_huggingface_across_added_token_overlaps` — the table
  above, as a hermetic `from_json` test. Reverting just the implementation fails
  it with `left: 7, right: 5`.
- `duplicate_added_token_contents_are_rejected_at_construction` — pins the
  `DuplicatePatternError` behaviour that makes that row unreachable.
- `vocab_size_only_counts_resolvable_ids` — every counted ID resolves via
  `id_to_token`, which is the property callers depend on.

`cargo test` is 230 passed / 0 failed (227 before, plus these three).
`cargo fmt --check` and `cargo clippy -- -D warnings` are clean. `cargo clippy
--all-targets` reports 4 errors, but all 4 are present on an unmodified `main`
(`examples/simple_bench.rs`, `src/models/bpe.rs`) and are untouched here.

End to end through `patch_transformers` on the real DeepSeek-V4 checkpoint:
`len(tokenizer)` now reports 129280, matching `tokenizers` exactly, the load no
longer raises, and encode/decode stay byte-identical to the HuggingFace backend
across ASCII, source code, CJK, emoji, unusual whitespace, and long inputs.

Made with [Cursor](https://cursor.com)