### PR TITLE
tokenizer: add encode_segments for segmented trusted/untrusted encoding

### DIFF
--- a/python/fastokens/_native.pyi
+++ b/python/fastokens/_native.pyi
@@ -158,6 +158,13 @@ class Tokenizer:
 
     def encode(self, input: str, add_special_tokens: bool = False) -> Encoding: ...
     def encode_ordinary(self, input: str) -> Encoding: ...
+    def encode_segments(self, segments: list[tuple[str, bool]]) -> Encoding:
+        """Encode a pre-segmented input, concatenating each segment's token ids.
+
+        ``segments`` is a list of ``(text, allow_special)`` pairs. Each segment is
+        tokenized independently; special/added tokens are recognized only in
+        segments with ``allow_special=True``. Mirrors legacy tiktoken / Dynamo
+        segmented encoding; no post-processor special tokens are inserted."""
 
     def encode_batch(
         self, inputs: list[str], add_special_tokens: bool = False

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -815,6 +815,35 @@ impl PyTokenizer {
         Py::new(py, state.build_single_encoding(ids))
     }
 
+    /// Encode a pre-segmented input, concatenating each segment's token ids.
+    ///
+    /// `segments` is a list of `(text, allow_special)` pairs. Each segment is
+    /// tokenized independently; special/added tokens are recognized only in
+    /// segments with `allow_special=True` (trusted chat-template output), so a
+    /// literal control token in an `allow_special=False` segment stays ordinary
+    /// content. Mirrors legacy tiktoken / Dynamo segmented encoding. No
+    /// post-processor special tokens are inserted. Truncation and padding (if
+    /// enabled) are applied to the concatenated result before returning.
+    fn encode_segments(
+        &self,
+        segments: Vec<(String, bool)>,
+        py: Python<'_>,
+    ) -> PyResult<Py<PyEncoding>> {
+        let state = self.read();
+        let segs: Vec<fastokens::EncodeSegment<'_>> = segments
+            .iter()
+            .map(|(text, allow_special)| fastokens::EncodeSegment {
+                text: text.as_str(),
+                allow_special: *allow_special,
+            })
+            .collect();
+        let ids = state
+            .inner
+            .encode_segments(&segs)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Py::new(py, state.build_single_encoding(ids))
+    }
+
     /// Encode a batch of inputs in parallel.
     ///
     /// Truncation is applied per-sequence; padding (if enabled) pads the

--- a/python/tests/test_encode_segments.py
+++ b/python/tests/test_encode_segments.py
@@ -1,0 +1,56 @@
+import json
+
+from fastokens._native import Tokenizer
+
+
+def _tokenizer() -> Tokenizer:
+    """A tiny BPE tokenizer with one special added token (`<end>` -> id 5) whose
+    literal characters are all in the model vocab, so encoding it as ordinary
+    content yields the per-character ids [0, 1, 2, 3, 4]."""
+    return Tokenizer.from_json_str(
+        json.dumps(
+            {
+                "added_tokens": [
+                    {
+                        "id": 5,
+                        "content": "<end>",
+                        "special": True,
+                        "single_word": False,
+                        "lstrip": False,
+                        "rstrip": False,
+                        "normalized": False,
+                    }
+                ],
+                "model": {
+                    "type": "BPE",
+                    "vocab": {"<": 0, "e": 1, "n": 2, "d": 3, ">": 4},
+                    "merges": [],
+                },
+            }
+        )
+    )
+
+
+def test_trusted_segment_recognizes_special_token():
+    tok = _tokenizer()
+    assert tok.encode_segments([("<end>", True)]).ids == [5]
+
+
+def test_untrusted_segment_encodes_special_text_as_ordinary():
+    tok = _tokenizer()
+    ids = tok.encode_segments([("<end>", False)]).ids
+    assert ids == [0, 1, 2, 3, 4]  # literal characters, not the special id
+    assert ids == tok.encode_ordinary("<end>").ids
+
+
+def test_segments_are_encoded_independently_and_concatenated():
+    tok = _tokenizer()
+    got = tok.encode_segments([("<end>", True), ("<end>", False)]).ids
+    assert got == [5, 0, 1, 2, 3, 4]
+
+
+def test_empty_segments():
+    tok = _tokenizer()
+    assert tok.encode_segments([]).ids == []
+    assert tok.encode_segments([("", False)]).ids == []
+    assert tok.encode_segments([("", True), ("", False)]).ids == []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,39 @@ pub struct TokenizerOptions {
     pub pcre2_limits: Pcre2Limits,
 }
 
+/// One piece of input for [`Tokenizer::encode_segments`].
+///
+/// A segment carries its own trust boundary: when `allow_special` is `true`,
+/// added/special vocabulary entries (e.g. `<|im_end|>`) in `text` are
+/// recognized as control tokens — appropriate for trusted chat-template output.
+/// When `false`, `text` is encoded as ordinary content, so a literal
+/// `<|im_end|>` becomes plain tokens and cannot be injected by untrusted input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EncodeSegment<'a> {
+    /// The text of this segment.
+    pub text: &'a str,
+    /// Whether special/added tokens are recognized within `text`.
+    pub allow_special: bool,
+}
+
+impl<'a> EncodeSegment<'a> {
+    /// A trusted segment whose special tokens are recognized.
+    pub fn special(text: &'a str) -> Self {
+        Self {
+            text,
+            allow_special: true,
+        }
+    }
+
+    /// An untrusted segment encoded as ordinary content.
+    pub fn ordinary(text: &'a str) -> Self {
+        Self {
+            text,
+            allow_special: false,
+        }
+    }
+}
+
 /// An LLM tokenizer backed by `tokenizer.json`.
 pub struct Tokenizer {
     added_tokens: Option<AddedTokens>,
@@ -697,6 +730,36 @@ impl Tokenizer {
     /// post-processing are preserved.
     pub fn encode_ordinary(&self, input: &str) -> Result<Vec<u32>, Error> {
         self.encode_inner(input, false, false)
+    }
+
+    /// Encode a pre-segmented input, concatenating the token ids of each
+    /// segment in order.
+    ///
+    /// This mirrors legacy tiktoken / Dynamo segmented encoding: each
+    /// [`EncodeSegment`] is tokenized **independently** and its trust boundary
+    /// is honored — special tokens are recognized only in segments with
+    /// `allow_special = true` (see [`EncodeSegment`]). Segments are never
+    /// flattened into a single string first, so the trust boundary between
+    /// control tokens and untrusted content is preserved, and no BPE merge
+    /// crosses a segment boundary.
+    ///
+    /// No post-processor special tokens (BOS/EOS) are inserted — the caller's
+    /// segments are expected to already carry the full rendered sequence.
+    pub fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Vec<u32>, Error> {
+        // Single-segment shortcut avoids a second allocation + copy.
+        if let [seg] = segments {
+            return self.encode_inner(seg.text, false, seg.allow_special);
+        }
+        let mut ids = Vec::new();
+        for seg in segments {
+            let seg_ids = self.encode_inner(seg.text, false, seg.allow_special)?;
+            if ids.is_empty() {
+                ids = seg_ids;
+            } else {
+                ids.extend_from_slice(&seg_ids);
+            }
+        }
+        Ok(ids)
     }
 
     fn encode_inner(
@@ -1826,6 +1889,50 @@ mod tests {
             // Round-trip: the ID must decode back to the same string.
             assert_eq!(tok.id_to_token(id.unwrap()), Some(*token));
         }
+    }
+
+    /// `encode_segments` honors the per-segment trust boundary and concatenates
+    /// each segment's ids without flattening or crossing BPE boundaries.
+    #[test]
+    fn encode_segments_honors_trust_boundary() {
+        let tok = Tokenizer::from_model("Qwen/Qwen3-0.6B").unwrap();
+        let special = "<|im_start|>";
+
+        // Trusted segment: the control token is recognized as a single id.
+        let trusted = tok
+            .encode_segments(&[EncodeSegment::special(special)])
+            .unwrap();
+        assert_eq!(trusted, tok.encode(special).unwrap());
+        assert_eq!(trusted.len(), 1, "control token should be one id");
+
+        // Untrusted segment: the same text is encoded as ordinary content and
+        // must NOT collapse to the special id.
+        let untrusted = tok
+            .encode_segments(&[EncodeSegment::ordinary(special)])
+            .unwrap();
+        assert_eq!(untrusted, tok.encode_ordinary(special).unwrap());
+        assert_ne!(untrusted, trusted);
+
+        // Mixed segments concatenate independently: a literal control token in
+        // the untrusted content segment stays ordinary.
+        let content = "hello <|im_start|> world";
+        let got = tok
+            .encode_segments(&[
+                EncodeSegment::special(special),
+                EncodeSegment::ordinary(content),
+            ])
+            .unwrap();
+        let mut want = tok.encode(special).unwrap();
+        want.extend(tok.encode_ordinary(content).unwrap());
+        assert_eq!(got, want);
+
+        // Empty input yields no tokens.
+        assert!(tok.encode_segments(&[]).unwrap().is_empty());
+        assert!(
+            tok.encode_segments(&[EncodeSegment::ordinary("")])
+                .unwrap()
+                .is_empty()
+        );
     }
 
     // Qwen2-VL's image token is located in the tokenizer_config.json's added_token_configs


### PR DESCRIPTION
Add `Tokenizer::encode_segments(&[EncodeSegment])` (and its Python binding), mirroring legacy tiktoken / Dynamo segmented encoding. Each `EncodeSegment` carries an `allow_special` trust boundary: special/added tokens are recognized only in trusted segments, so a literal control token (e.g. `<|im_end|>`) in an untrusted content segment is encoded as ordinary text and cannot be injected. Segments are encoded independently and concatenated — never flattened, so the trust boundary holds and no BPE merge crosses a segment boundary. No post-processor BOS/EOS is inserted; the segments carry the full sequence.

This provides the method Dynamo's `Encoder::encode_segments` needs.