### PR TITLE
fix: implement add_tokens instead of silently ignoring it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
         run: pip install transformers==${{ matrix.transformers }} pytest
 
       - name: Test patch_transformers
-        run: pytest python/tests/test_patch_transformers.py -v
+        run: pytest python/tests/test_patch_transformers.py python/tests/test_add_tokens.py -v

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ tokens = tokenizer("Hello, world!")
 assert tokens["input_ids"] == [22177, 1044, 4304, 1033]
 ```
 
+#### Extending the vocabulary
+
+`add_tokens` / `add_special_tokens` work as they do on a `tokenizers` backend,
+assigning the same ids. This is what serving stacks call to reconcile a
+checkpoint whose embedding matrix is padded above the tokenizer's token count:
+placeholder tokens are appended until the two agree.
+
+```python
+tokenizer.add_tokens([f"<|padding_token_{i}|>" for i in range(num_embeddings - len(tokenizer))])
+assert len(tokenizer) == num_embeddings
+```
+
+Passing `split_special_tokens=True` encodes special tokens found in the text as
+ordinary text instead of as control-token ids, so a control token appearing in
+untrusted input cannot be injected. The rest of the added vocabulary still
+matches; re-register those tokens as special first to cover them too.
+
 ### Standalone usage
 
 ```python

--- a/python/fastokens/_compat.py
+++ b/python/fastokens/_compat.py
@@ -78,6 +78,8 @@ class _TokenizerShim:
                 f"got {type(src).__name__}"
             )
         self._encode_special_tokens: bool = False
+        # Whether add_tokens has grown the vocabulary past what `_json` holds.
+        self._vocab_extended: bool = False
 
     # -- Pickle / copy --------------------------------------------------
 
@@ -112,7 +114,11 @@ class _TokenizerShim:
         memo[id(self)] = new
         new._json = self._json
         new._pcre2_options = dict(self._pcre2_options)
-        new._fast = Tokenizer.from_json_str(self._json, **new._pcre2_options)
+        # Once the vocabulary has been extended the source JSON is no longer
+        # the whole tokenizer, so the copy has to be built from the live state.
+        source = self.to_str() if self._vocab_extended else self._json
+        new._vocab_extended = self._vocab_extended
+        new._fast = Tokenizer.from_json_str(source, **new._pcre2_options)
         trunc = self._fast.truncation
         if trunc is not None:
             new._fast.enable_truncation(**trunc)
@@ -160,6 +166,9 @@ class _TokenizerShim:
         cfg = json.loads(self._json)
         cfg["truncation"] = self._fast.truncation
         cfg["padding"] = self._fast.padding
+        # Read the added tokens back from the backend rather than the source
+        # JSON, so tokens added after construction survive serialization.
+        cfg["added_tokens"] = self._fast.added_tokens()
         if pretty:
             return json.dumps(cfg, indent=2, ensure_ascii=False)
         return json.dumps(cfg, ensure_ascii=False)
@@ -250,7 +259,11 @@ class _TokenizerShim:
             raise NotImplementedError("pair encoding is not supported by fastokens")
         if is_pretokenized:
             raise NotImplementedError("pre-tokenized input is not supported by fastokens")
-        return self._fast.encode(sequence, add_special_tokens=add_special_tokens)
+        return self._fast.encode(
+            sequence,
+            add_special_tokens=add_special_tokens,
+            split_special_tokens=self._encode_special_tokens,
+        )
 
     def encode_batch(
         self,
@@ -263,7 +276,11 @@ class _TokenizerShim:
             raise NotImplementedError(
                 "pair/pre-tokenized batch encoding is not supported by fastokens"
             )
-        return self._fast.encode_batch(inputs, add_special_tokens=add_special_tokens)
+        return self._fast.encode_batch(
+            inputs,
+            add_special_tokens=add_special_tokens,
+            split_special_tokens=self._encode_special_tokens,
+        )
 
     def encode_batch_fast(
         self,
@@ -275,7 +292,11 @@ class _TokenizerShim:
             raise NotImplementedError(
                 "pair/pre-tokenized batch encoding is not supported by fastokens"
             )
-        return self._fast.encode_batch(inputs, add_special_tokens=add_special_tokens)
+        return self._fast.encode_batch(
+            inputs,
+            add_special_tokens=add_special_tokens,
+            split_special_tokens=self._encode_special_tokens,
+        )
 
     # -- Post-processing ------------------------------------------------
 
@@ -316,37 +337,66 @@ class _TokenizerShim:
             tok = self._fast.id_to_token(i)
             if tok is not None:
                 vocab[tok] = i
+        # An added token can sit above the vocabulary size when the declared ids
+        # leave a gap, so the id scan alone can miss one.
+        for entry in self._fast.added_tokens():
+            vocab[entry["content"]] = entry["id"]
         return vocab
 
     def get_vocab_size(self, with_added_tokens: bool = True) -> int:
+        # fastokens reports one number for both: the count of distinct token
+        # strings, which is `get_vocab_size(True)` upstream. `False` should be
+        # the base vocabulary alone, but the backend does not track the split,
+        # and over-reporting is the safer direction for callers that size
+        # embedding tables or logit masks from it.
         return self._fast.vocab_size
 
     def get_added_tokens_decoder(self) -> dict[int, object]:
-        try:
-            cfg = json.loads(self._json)
-        except (json.JSONDecodeError, TypeError):
-            return {}
-        result: dict[int, object] = {}
-        for entry in cfg.get("added_tokens", []):
-            tid = entry.get("id")
-            if tid is not None:
-                result[tid] = _AddedTokenInfo(
-                    content=entry.get("content", ""),
-                    single_word=entry.get("single_word", False),
-                    lstrip=entry.get("lstrip", False),
-                    rstrip=entry.get("rstrip", False),
-                    normalized=entry.get("normalized", True),
-                    special=entry.get("special", False),
-                )
-        return result
+        return {
+            entry["id"]: _AddedTokenInfo(
+                content=entry["content"],
+                single_word=entry["single_word"],
+                lstrip=entry["lstrip"],
+                rstrip=entry["rstrip"],
+                normalized=entry["normalized"],
+                special=entry["special"],
+            )
+            for entry in self._fast.added_tokens()
+        }
 
-    # -- Token management (no-ops) --------------------------------------
+    # -- Token management -----------------------------------------------
 
     def add_tokens(self, tokens) -> int:
-        return 0
+        """Extend the vocabulary, returning the number of tokens added.
+
+        Accepts plain strings and ``AddedToken``-like objects. Ids are assigned
+        as HuggingFace ``tokenizers`` assigns them, so a loader that pads a
+        tokenizer up to a checkpoint's embedding count lands the placeholders on
+        the padded rows.
+        """
+        return self._add_tokens(tokens, special=False)
 
     def add_special_tokens(self, special_tokens) -> int:
-        return 0
+        """:meth:`add_tokens` for special tokens.
+
+        A token already in the vocabulary is not duplicated; it is promoted to
+        special, which is what makes ``encode_special_tokens`` skip it.
+        """
+        return self._add_tokens(special_tokens, special=True)
+
+    def _add_tokens(self, tokens, special: bool) -> int:
+        specs = [
+            token
+            if hasattr(token, "content")
+            # `AddedToken.from(content, special)` leaves special tokens
+            # unnormalized; mirror that for bare strings.
+            else _AddedTokenInfo(content=token, normalized=not special, special=special)
+            for token in tokens
+        ]
+        added = self._fast.add_tokens(specs)
+        if added:
+            self._vocab_extended = True
+        return len(added)
 
     # -- Component accessors --------------------------------------------
 

--- a/python/fastokens/_compat.py
+++ b/python/fastokens/_compat.py
@@ -166,12 +166,41 @@ class _TokenizerShim:
         cfg = json.loads(self._json)
         cfg["truncation"] = self._fast.truncation
         cfg["padding"] = self._fast.padding
-        # Read the added tokens back from the backend rather than the source
-        # JSON, so tokens added after construction survive serialization.
-        cfg["added_tokens"] = self._fast.added_tokens()
+        cfg["added_tokens"] = self._added_tokens(cfg.get("added_tokens") or [])
         if pretty:
             return json.dumps(cfg, indent=2, ensure_ascii=False)
         return json.dumps(cfg, ensure_ascii=False)
+
+    def _added_tokens(self, source: list[dict] | None = None) -> list[dict]:
+        """The effective ``added_tokens`` array: source entries plus any added
+        after construction.
+
+        Source-JSON entries are kept verbatim so a load/save round-trip does not
+        rewrite fields the backend defaults differently — notably ``normalized``,
+        which the backend stores as ``False`` when a source entry omits it but
+        HuggingFace treats as ``True``. The live ``special`` flag is overlaid so
+        promotions via :meth:`add_special_tokens` are reflected, and tokens added
+        after construction are appended in id order.
+        """
+        if source is None:
+            source = json.loads(self._json).get("added_tokens") or []
+        live_by_id = {entry["id"]: entry for entry in self._fast.added_tokens()}
+        result: list[dict] = []
+        seen: set[int] = set()
+        for entry in source:
+            tid = entry.get("id")
+            seen.add(tid)
+            live = live_by_id.get(tid)
+            if live is None:
+                result.append(entry)
+            else:
+                # Only `special` can change for a token already declared in the
+                # source JSON (a promotion); every other field is immutable.
+                result.append({**entry, "special": live["special"]})
+        for tid, live in live_by_id.items():
+            if tid not in seen:
+                result.append(live)
+        return result
 
     def save(self, path: str, pretty: bool = True) -> None:
         Path(path).write_text(self.to_str(pretty=pretty), encoding="utf-8")
@@ -332,6 +361,18 @@ class _TokenizerShim:
         return self._fast.token_to_id(token)
 
     def get_vocab(self, with_added_tokens: bool = True) -> dict[str, int]:
+        added = self._fast.added_tokens()
+        if not with_added_tokens:
+            # Exclude the added vocabulary so `transformers.get_added_vocab()`,
+            # which diffs `get_vocab(False)` against `get_vocab(True)`, actually
+            # sees the added tokens instead of an empty difference.
+            added_ids = {entry["id"] for entry in added}
+            return {
+                tok: i
+                for i in range(self._fast.vocab_size)
+                if i not in added_ids
+                and (tok := self._fast.id_to_token(i)) is not None
+            }
         vocab = {}
         for i in range(self._fast.vocab_size):
             tok = self._fast.id_to_token(i)
@@ -339,7 +380,7 @@ class _TokenizerShim:
                 vocab[tok] = i
         # An added token can sit above the vocabulary size when the declared ids
         # leave a gap, so the id scan alone can miss one.
-        for entry in self._fast.added_tokens():
+        for entry in added:
             vocab[entry["content"]] = entry["id"]
         return vocab
 
@@ -352,17 +393,22 @@ class _TokenizerShim:
         return self._fast.vocab_size
 
     def get_added_tokens_decoder(self) -> dict[int, object]:
-        return {
-            entry["id"]: _AddedTokenInfo(
-                content=entry["content"],
-                single_word=entry["single_word"],
-                lstrip=entry["lstrip"],
-                rstrip=entry["rstrip"],
-                normalized=entry["normalized"],
-                special=entry["special"],
+        result: dict[int, object] = {}
+        for entry in self._added_tokens():
+            tid = entry.get("id")
+            if tid is None:
+                continue
+            result[tid] = _AddedTokenInfo(
+                content=entry.get("content", ""),
+                single_word=entry.get("single_word", False),
+                lstrip=entry.get("lstrip", False),
+                rstrip=entry.get("rstrip", False),
+                # HuggingFace treats a missing `normalized` as True; the backend
+                # would report False, so default here from the source entry.
+                normalized=entry.get("normalized", True),
+                special=entry.get("special", False),
             )
-            for entry in self._fast.added_tokens()
-        }
+        return result
 
     # -- Token management -----------------------------------------------
 
@@ -385,18 +431,34 @@ class _TokenizerShim:
         return self._add_tokens(special_tokens, special=True)
 
     def _add_tokens(self, tokens, special: bool) -> int:
-        specs = [
-            token
-            if hasattr(token, "content")
-            # `AddedToken.from(content, special)` leaves special tokens
-            # unnormalized; mirror that for bare strings.
-            else _AddedTokenInfo(content=token, normalized=not special, special=special)
-            for token in tokens
-        ]
+        specs = [self._coerce_token(token, special) for token in tokens]
         added = self._fast.add_tokens(specs)
         if added:
             self._vocab_extended = True
         return len(added)
+
+    @staticmethod
+    def _coerce_token(token, special: bool):
+        if not hasattr(token, "content"):
+            # `AddedToken.from(content, special)` leaves special tokens
+            # unnormalized; mirror that for bare strings.
+            return _AddedTokenInfo(content=token, normalized=not special, special=special)
+        if special and not getattr(token, "special", False):
+            # `Tokenizer.add_special_tokens` always marks its arguments special
+            # in HuggingFace; an `AddedToken(..., special=False)` passed here
+            # must still be registered special, or `encode_special_tokens` would
+            # not skip it and a control-token string in untrusted input would
+            # produce a real control-token id. Copy the object's flags rather
+            # than mutating the caller's object.
+            return _AddedTokenInfo(
+                content=token.content,
+                single_word=getattr(token, "single_word", False),
+                lstrip=getattr(token, "lstrip", False),
+                rstrip=getattr(token, "rstrip", False),
+                normalized=getattr(token, "normalized", True),
+                special=True,
+            )
+        return token
 
     # -- Component accessors --------------------------------------------
 

--- a/python/fastokens/_native.pyi
+++ b/python/fastokens/_native.pyi
@@ -1,4 +1,14 @@
-from typing import Optional
+from typing import Any, Optional, Protocol
+
+class AddedTokenLike(Protocol):
+    """Any object with the attributes of a ``tokenizers.AddedToken``."""
+
+    content: str
+    single_word: bool
+    lstrip: bool
+    rstrip: bool
+    normalized: bool
+    special: bool
 
 class Encoding:
     """Rust-backed encoding returned by tokenizer encoding methods."""
@@ -156,7 +166,18 @@ class Tokenizer:
 
     def num_special_tokens_to_add(self, is_pair: bool) -> int: ...
 
-    def encode(self, input: str, add_special_tokens: bool = False) -> Encoding: ...
+    def encode(
+        self,
+        input: str,
+        add_special_tokens: bool = False,
+        split_special_tokens: bool = False,
+    ) -> Encoding:
+        """Encode ``input``.
+
+        With ``split_special_tokens``, special added tokens are encoded as
+        ordinary text rather than as control-token ids; the rest of the added
+        vocabulary still matches."""
+
     def encode_ordinary(self, input: str) -> Encoding: ...
     def encode_segments(self, segments: list[tuple[str, bool]]) -> Encoding:
         """Encode a pre-segmented input, concatenating each segment's token ids.
@@ -167,7 +188,10 @@ class Tokenizer:
         segmented encoding; no post-processor special tokens are inserted."""
 
     def encode_batch(
-        self, inputs: list[str], add_special_tokens: bool = False
+        self,
+        inputs: list[str],
+        add_special_tokens: bool = False,
+        split_special_tokens: bool = False,
     ) -> list[Encoding]: ...
     def encode_batch_flat(
         self, inputs: list[str], add_special_tokens: bool = False
@@ -191,3 +215,15 @@ class Tokenizer:
 
     def token_to_id(self, token: str) -> Optional[int]: ...
     def id_to_token(self, id: int) -> Optional[str]: ...
+
+    def added_tokens(self) -> list[dict[str, Any]]:
+        """The added-vocabulary entries, as ``tokenizer.json`` serializes them,
+        including any added since construction."""
+
+    def add_tokens(self, tokens: list[AddedTokenLike]) -> list[tuple[str, int]]:
+        """Extend the vocabulary, returning the ``(content, id)`` of every entry
+        created or changed.
+
+        Ids are assigned as HuggingFace ``tokenizers`` assigns them: a content
+        already in the vocabulary keeps its id and only its flags can change,
+        anything else is appended above the vocabulary."""

--- a/python/fastokens/_native.pyi
+++ b/python/fastokens/_native.pyi
@@ -194,7 +194,10 @@ class Tokenizer:
         split_special_tokens: bool = False,
     ) -> list[Encoding]: ...
     def encode_batch_flat(
-        self, inputs: list[str], add_special_tokens: bool = False
+        self,
+        inputs: list[str],
+        add_special_tokens: bool = False,
+        split_special_tokens: bool = False,
     ) -> tuple[bytes, bytes]:
         """Encode a batch into a single flat token buffer for high-throughput
         bulk tokenization. Returns ``(ids, offsets)``: ``ids`` is every input's

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -990,15 +990,21 @@ impl PyTokenizer {
     /// the whole result is two buffers — which is what makes bulk encoding fast
     /// from Python. Truncation is applied per input; padding does not apply
     /// (the result is ragged, addressed by `offsets`).
-    #[pyo3(signature = (inputs, add_special_tokens = false))]
+    ///
+    /// `split_special_tokens` has the same meaning as in [`Self::encode`], so
+    /// the bulk path can suppress control-token IDs for untrusted input the
+    /// same way the per-encoding paths do.
+    #[pyo3(signature = (inputs, add_special_tokens = false, split_special_tokens = false))]
     fn encode_batch_flat<'py>(
         &self,
         inputs: Vec<String>,
         add_special_tokens: bool,
+        split_special_tokens: bool,
         py: Python<'py>,
     ) -> PyResult<(Bound<'py, PyBytes>, Bound<'py, PyBytes>)> {
         use rayon::prelude::*;
 
+        let policy = added_token_policy(split_special_tokens);
         let state = self.read();
         let mut batch: Vec<Vec<u32>> = py.allow_threads(|| {
             inputs
@@ -1006,7 +1012,7 @@ impl PyTokenizer {
                 .map(|s| {
                     state
                         .inner
-                        .encode_with_special_tokens(s.as_str(), add_special_tokens)
+                        .encode_with_policy(s.as_str(), add_special_tokens, policy)
                         .map_err(|e| PyValueError::new_err(e.to_string()))
                 })
                 .collect::<PyResult<Vec<_>>>()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -443,6 +443,40 @@ impl TokenizerState {
     }
 }
 
+/// A token to add to the vocabulary, extracted from any object exposing the
+/// attributes of a `tokenizers.AddedToken` (which `transformers` hands to
+/// `add_tokens`).
+#[derive(FromPyObject)]
+struct PyNewToken {
+    content: String,
+    single_word: bool,
+    lstrip: bool,
+    rstrip: bool,
+    normalized: bool,
+    special: bool,
+}
+
+impl From<PyNewToken> for fastokens::NewToken {
+    fn from(token: PyNewToken) -> Self {
+        Self {
+            content: token.content,
+            single_word: token.single_word,
+            lstrip: token.lstrip,
+            rstrip: token.rstrip,
+            normalized: token.normalized,
+            special: token.special,
+        }
+    }
+}
+
+fn added_token_policy(split_special_tokens: bool) -> fastokens::AddedTokenPolicy {
+    if split_special_tokens {
+        fastokens::AddedTokenPolicy::SkipSpecial
+    } else {
+        fastokens::AddedTokenPolicy::All
+    }
+}
+
 /// An LLM tokenizer backed by `tokenizer.json`.
 #[pyclass(name = "Tokenizer")]
 struct PyTokenizer {
@@ -823,19 +857,30 @@ impl PyTokenizer {
 
     /// Run the full encoding pipeline.
     ///
+    /// With `split_special_tokens`, special added tokens in `input` are encoded
+    /// as ordinary text instead of as control-token IDs; the rest of the added
+    /// vocabulary still matches. This is what `transformers` asks for when a
+    /// caller passes `split_special_tokens=True` to keep untrusted text from
+    /// producing control tokens.
+    ///
     /// Truncation and padding configured via `enable_truncation` /
     /// `enable_padding` are applied before returning.
-    #[pyo3(signature = (input, add_special_tokens = false))]
+    #[pyo3(signature = (input, add_special_tokens = false, split_special_tokens = false))]
     fn encode(
         &self,
         input: &str,
         add_special_tokens: bool,
+        split_special_tokens: bool,
         py: Python<'_>,
     ) -> PyResult<Py<PyEncoding>> {
         let state = self.read();
         let ids = state
             .inner
-            .encode_with_special_tokens(input, add_special_tokens)
+            .encode_with_policy(
+                input,
+                add_special_tokens,
+                added_token_policy(split_special_tokens),
+            )
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
         Py::new(py, state.build_single_encoding(ids))
     }
@@ -885,24 +930,28 @@ impl PyTokenizer {
 
     /// Encode a batch of inputs in parallel.
     ///
+    /// `split_special_tokens` has the same meaning as in [`Self::encode`].
+    ///
     /// Truncation is applied per-sequence; padding (if enabled) pads the
     /// batch to a uniform length.
-    #[pyo3(signature = (inputs, add_special_tokens = false))]
+    #[pyo3(signature = (inputs, add_special_tokens = false, split_special_tokens = false))]
     fn encode_batch(
         &self,
         inputs: Vec<String>,
         add_special_tokens: bool,
+        split_special_tokens: bool,
         py: Python<'_>,
     ) -> PyResult<Vec<Py<PyEncoding>>> {
         use rayon::prelude::*;
 
+        let policy = added_token_policy(split_special_tokens);
         let state = self.read();
         let mut batch: Vec<Vec<u32>> = inputs
             .par_iter()
             .map(|s| {
                 state
                     .inner
-                    .encode_with_special_tokens(s.as_str(), add_special_tokens)
+                    .encode_with_policy(s.as_str(), add_special_tokens, policy)
                     .map_err(|e| PyValueError::new_err(e.to_string()))
             })
             .collect::<PyResult<Vec<_>>>()?;
@@ -1079,6 +1128,51 @@ impl PyTokenizer {
     #[getter]
     fn vocab_size(&self) -> usize {
         self.read().inner.vocab_size()
+    }
+
+    /// The added-vocabulary entries, as `tokenizer.json` would serialize them.
+    ///
+    /// Reflects tokens added since construction, so callers that re-serialize
+    /// the tokenizer do not lose them.
+    fn added_tokens<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        self.read()
+            .inner
+            .added_token_configs()
+            .iter()
+            .map(|config| {
+                let entry = PyDict::new(py);
+                entry.set_item("id", config.id)?;
+                entry.set_item("content", &config.content)?;
+                entry.set_item("single_word", config.single_word)?;
+                entry.set_item("lstrip", config.lstrip)?;
+                entry.set_item("rstrip", config.rstrip)?;
+                entry.set_item("normalized", config.normalized)?;
+                entry.set_item("special", config.special)?;
+                Ok(entry)
+            })
+            .collect()
+    }
+
+    /// Extend the vocabulary, returning the `(content, id)` of every entry
+    /// created or changed.
+    ///
+    /// `tokens` are objects carrying the attributes of a
+    /// `tokenizers.AddedToken`. IDs are assigned exactly as HuggingFace
+    /// `tokenizers` assigns them: a content already in the vocabulary keeps its
+    /// ID (only its flags can change), anything else is appended above the
+    /// vocabulary. Adding a content that is already present with the same flags
+    /// changes nothing and is not reported.
+    fn add_tokens(&self, tokens: Vec<PyNewToken>) -> PyResult<Vec<(String, u32)>> {
+        let tokens: Vec<fastokens::NewToken> = tokens.into_iter().map(Into::into).collect();
+        let added = self
+            .write()
+            .inner
+            .add_tokens(&tokens)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Ok(added
+            .into_iter()
+            .map(|config| (config.content, config.id))
+            .collect())
     }
 }
 

--- a/python/tests/test_add_tokens.py
+++ b/python/tests/test_add_tokens.py
@@ -10,7 +10,7 @@ import pickle
 
 import pytest
 
-from fastokens._compat import _TokenizerShim
+from fastokens._compat import _AddedTokenInfo, _TokenizerShim
 
 # Byte-level alphabet characters, one model token each, so arbitrary ASCII
 # encodes to one id per character.
@@ -169,3 +169,61 @@ def test_encode_special_tokens_splits_only_special_tokens(shim):
 
     # Batch encoding honors the flag the same way.
     assert list(shim.encode_batch([text])[0].ids) == list(split)
+
+
+def test_get_vocab_without_added_tokens_excludes_them(shim):
+    """`transformers.get_added_vocab()` diffs get_vocab(False) vs get_vocab(True);
+    the added tokens must show up in that difference."""
+    full = shim.get_vocab(with_added_tokens=True)
+    base = shim.get_vocab(with_added_tokens=False)
+    added = {content for content, _ in ADDED}
+
+    assert added <= set(full), "added tokens must be in the full vocab"
+    assert added.isdisjoint(base), "added tokens must be absent from the base vocab"
+    assert {tok for tok in full if tok not in base} == added
+
+
+def test_encode_batch_flat_honors_split_special_tokens(shim):
+    """The bulk flat path must suppress control tokens like the other paths."""
+    import array
+
+    eot = shim.token_to_id("<|endoftext|>")
+    text = "a<|endoftext|>b"
+
+    def flat_ids(split):
+        raw, _offsets = shim._fast.encode_batch_flat([text], split_special_tokens=split)
+        return list(array.array("I", bytes(raw)))
+
+    assert eot in flat_ids(False)
+    assert eot not in flat_ids(True), (
+        "a control token in untrusted text must not survive the flat path"
+    )
+
+
+def test_add_special_tokens_forces_special_on_addedtoken_object(shim):
+    """`add_special_tokens` must mark its arguments special even when handed an
+    ``AddedToken(..., special=False)``, matching HuggingFace."""
+    token = _AddedTokenInfo(content="<ctrl>", special=False)
+    assert shim.add_special_tokens([token]) == 1
+
+    tid = shim.token_to_id("<ctrl>")
+    assert shim.get_added_tokens_decoder()[tid].special is True
+
+    shim.encode_special_tokens = True
+    ids = shim.encode("a<ctrl>b", add_special_tokens=False).ids
+    assert tid not in ids, "a promoted special token must be split like the rest"
+
+
+def test_added_token_missing_normalized_defaults_to_true_and_round_trips():
+    """A source entry that omits ``normalized`` is True (HF default), and a
+    load/save round-trip must not rewrite it to False."""
+    cfg = json.loads(tokenizer_json())
+    entry = cfg["added_tokens"][0]
+    del entry["normalized"]
+    tid = entry["id"]
+    shim = _TokenizerShim(json.dumps(cfg))
+
+    assert shim.get_added_tokens_decoder()[tid].normalized is True
+
+    out_entry = next(e for e in json.loads(shim.to_str())["added_tokens"] if e["id"] == tid)
+    assert "normalized" not in out_entry, "round-trip must not inject normalized=false"

--- a/python/tests/test_add_tokens.py
+++ b/python/tests/test_add_tokens.py
@@ -1,0 +1,171 @@
+"""Tests for vocabulary extension and special-token splitting in the shim.
+
+These exercise `_TokenizerShim` directly — the object `patch_transformers`
+installs as the `transformers` backend — so they run without transformers.
+"""
+
+import copy
+import json
+import pickle
+
+import pytest
+
+from fastokens._compat import _TokenizerShim
+
+# Byte-level alphabet characters, one model token each, so arbitrary ASCII
+# encodes to one id per character.
+BASE_VOCAB = {chr(code): code - 33 for code in range(33, 127)}
+BASE_VOCAB[" "] = len(BASE_VOCAB)
+BASE_SIZE = len(BASE_VOCAB)
+
+ADDED = [("<|endoftext|>", True), ("<think>", False)]
+
+
+def added_entry(id, content, special):
+    return {
+        "id": id,
+        "content": content,
+        "single_word": False,
+        "lstrip": False,
+        "rstrip": False,
+        "normalized": False,
+        "special": special,
+    }
+
+
+def tokenizer_json():
+    return json.dumps({
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [
+            added_entry(BASE_SIZE + offset, content, special)
+            for offset, (content, special) in enumerate(ADDED)
+        ],
+        "normalizer": None,
+        "pre_tokenizer": None,
+        "post_processor": None,
+        "decoder": None,
+        "model": {
+            "type": "BPE",
+            "dropout": None,
+            "unk_token": None,
+            "continuing_subword_prefix": None,
+            "end_of_word_suffix": None,
+            "fuse_unk": False,
+            "byte_fallback": False,
+            "ignore_merges": True,
+            "vocab": BASE_VOCAB,
+            "merges": [],
+        },
+    })
+
+
+@pytest.fixture
+def shim():
+    return _TokenizerShim(tokenizer_json())
+
+
+DECLARED_SIZE = BASE_SIZE + len(ADDED)
+
+
+def test_declared_vocabulary_is_counted(shim):
+    assert shim.get_vocab_size() == DECLARED_SIZE
+
+
+def test_add_tokens_pads_up_to_an_embedding_count(shim):
+    """The case this exists for: a checkpoint with a padded embedding matrix.
+
+    A loader appends placeholder tokens until the tokenizer matches the
+    embedding count, then indexes every id below it.
+    """
+    num_model_embeddings = DECLARED_SIZE + 24
+    placeholders = [
+        f"<|padding_token_{i}|>"
+        for i in range(num_model_embeddings - shim.get_vocab_size())
+    ]
+
+    assert shim.add_tokens(placeholders) == 24
+    assert shim.get_vocab_size() == num_model_embeddings
+
+    # Contiguous from the old size, so they land on the padded rows.
+    assert [shim.token_to_id(t) for t in placeholders] == list(
+        range(DECLARED_SIZE, num_model_embeddings)
+    )
+    for id in range(num_model_embeddings):
+        assert shim.id_to_token(id) is not None, f"id {id} has no token"
+
+
+def test_added_tokens_appear_in_the_vocabulary_views(shim):
+    shim.add_tokens(["<|pad|>"])
+    id = shim.token_to_id("<|pad|>")
+
+    assert shim.get_vocab()["<|pad|>"] == id
+    assert len(shim.get_vocab()) == shim.get_vocab_size()
+
+    decoder = shim.get_added_tokens_decoder()
+    assert decoder[id].content == "<|pad|>"
+    assert decoder[id].special is False
+
+
+def test_add_tokens_is_idempotent(shim):
+    assert shim.add_tokens(["<|pad|>"]) == 1
+    size = shim.get_vocab_size()
+
+    assert shim.add_tokens(["<|pad|>"]) == 0
+    assert shim.get_vocab_size() == size
+
+
+def test_add_tokens_recognizes_the_new_token_when_encoding(shim):
+    shim.add_tokens(["<|pad|>"])
+    pad = shim.token_to_id("<|pad|>")
+
+    assert pad in shim.encode("a<|pad|>b", add_special_tokens=False).ids
+    assert shim.decode([pad], skip_special_tokens=False) == "<|pad|>"
+
+
+def test_add_special_tokens_promotes_an_existing_token(shim):
+    """What makes `split_special_tokens=True` cover ordinary added tokens.
+
+    Callers re-register every added token as special before encoding untrusted
+    text, since the flag only skips tokens marked special.
+    """
+    think = shim.token_to_id("<think>")
+    size = shim.get_vocab_size()
+    assert shim.get_added_tokens_decoder()[think].special is False
+
+    assert shim.add_special_tokens(["<think>"]) == 1
+
+    assert shim.token_to_id("<think>") == think, "promotion must not move the id"
+    assert shim.get_vocab_size() == size, "no new string, no new entry"
+    assert shim.get_added_tokens_decoder()[think].special is True
+
+
+def test_added_tokens_survive_serialization(shim):
+    shim.add_tokens(["<|pad|>"])
+    id = shim.token_to_id("<|pad|>")
+
+    assert json.loads(shim.to_str())["added_tokens"][-1]["content"] == "<|pad|>"
+    for clone in (pickle.loads(pickle.dumps(shim)), copy.deepcopy(shim)):
+        assert clone.get_vocab_size() == shim.get_vocab_size()
+        assert clone.token_to_id("<|pad|>") == id
+        assert clone.get_added_tokens_decoder()[id].content == "<|pad|>"
+
+
+def test_encode_special_tokens_splits_only_special_tokens(shim):
+    """`transformers` sets this flag for `split_special_tokens=True`."""
+    eot = shim.token_to_id("<|endoftext|>")
+    think = shim.token_to_id("<think>")
+    text = "a<|endoftext|>b<think>c"
+
+    matched = shim.encode(text, add_special_tokens=False).ids
+    assert eot in matched and think in matched
+
+    shim.encode_special_tokens = True
+    split = shim.encode(text, add_special_tokens=False).ids
+    assert eot not in split, "a control token in untrusted text must not survive"
+    assert think in split, "only special tokens are split"
+    assert shim.decode(split, skip_special_tokens=False) == text
+
+    # Batch encoding honors the flag the same way.
+    assert list(shim.encode_batch([text])[0].ids) == list(split)

--- a/python/tests/test_patch_transformers.py
+++ b/python/tests/test_patch_transformers.py
@@ -55,3 +55,52 @@ def test_unpatch_restores_backend():
     assert not isinstance(tok._tokenizer, _TokenizerShim), (
         "backend should be original tokenizers.Tokenizer after unpatch"
     )
+
+
+PADDING_TOKENS = [f"<|padding_token_{i}|>" for i in range(4)]
+
+
+def test_add_tokens_matches_unpatched_backend():
+    """Padding a tokenizer up to a checkpoint's embedding count.
+
+    Checkpoints whose embedding matrix is padded above the tokenizer's token
+    count are squared up by appending placeholder tokens until the two agree.
+    The loader then asserts the vocabulary actually grew, so a backend that
+    ignores the request cannot serve the model at all.
+    """
+
+    def pad(tokenizer):
+        added = tokenizer.add_tokens(PADDING_TOKENS)
+        ids = [tokenizer.convert_tokens_to_ids(t) for t in PADDING_TOKENS]
+        return added, len(tokenizer), ids
+
+    import fastokens
+
+    reference = pad(transformers.AutoTokenizer.from_pretrained(MODEL))
+
+    fastokens.patch_transformers()
+    patched = pad(transformers.AutoTokenizer.from_pretrained(MODEL))
+
+    assert patched == reference, f"expected {reference}, got {patched}"
+
+
+def test_split_special_tokens_matches_unpatched_backend():
+    """Control tokens in untrusted text must not become control-token ids."""
+    import fastokens
+
+    text = "<|im_start|>user\n<think>hello<|im_end|>"
+
+    def encode(tokenizer, split):
+        return tokenizer(text, add_special_tokens=False, split_special_tokens=split)[
+            "input_ids"
+        ]
+
+    unpatched = transformers.AutoTokenizer.from_pretrained(MODEL)
+    reference = {split: encode(unpatched, split) for split in (False, True)}
+    assert reference[False] != reference[True], "model must have special tokens to split"
+
+    fastokens.patch_transformers()
+    tok = transformers.AutoTokenizer.from_pretrained(MODEL)
+
+    for split, expected in reference.items():
+        assert encode(tok, split) == expected, f"mismatch for split_special_tokens={split}"

--- a/src/added_tokens.rs
+++ b/src/added_tokens.rs
@@ -13,6 +13,10 @@ use crate::json_structs::AddedTokenConfig;
 /// through normalization, pre-tokenization and the model as usual.
 pub struct AddedTokens {
     daac: DoubleArrayAhoCorasick<u32>,
+    /// The entries this set was compiled from. Kept because compilation is
+    /// lossy — `single_word` and `normalized` are not represented in the
+    /// matcher — so an extended set cannot be rebuilt from the fields below.
+    configs: Vec<AddedTokenConfig>,
     /// Token lengths (in bytes) indexed by token ID, for matched tokens only.
     /// Non-added token IDs map to 0.
     token_lens: Vec<usize>,
@@ -110,6 +114,7 @@ impl AddedTokens {
 
         Ok(Some(Self {
             daac,
+            configs: configs.to_vec(),
             token_lens,
             lstrip,
             rstrip,
@@ -119,6 +124,14 @@ impl AddedTokens {
             content_to_id,
             special_ids,
         }))
+    }
+
+    /// The entries this set was built from, in declaration order.
+    ///
+    /// Callers that extend the vocabulary append to this and rebuild with
+    /// [`Self::from_configs`].
+    pub fn configs(&self) -> &[AddedTokenConfig] {
+        &self.configs
     }
 
     /// Look up the string content of an added token by ID.
@@ -177,6 +190,18 @@ impl AddedTokens {
     /// emitted as [`Segment::Token`]; the gaps between them as
     /// [`Segment::Text`].
     pub fn split<'a>(&self, input: &'a str) -> Vec<Segment<'a>> {
+        self.split_with(input, false)
+    }
+
+    /// Split `input`, optionally leaving special tokens as ordinary text.
+    ///
+    /// With `skip_special`, an entry flagged `special` is consumed by the scan
+    /// but emitted as part of the surrounding [`Segment::Text`] instead of as a
+    /// [`Segment::Token`], so control-token strings in untrusted input cannot
+    /// produce control-token IDs. Non-special added tokens still match. This is
+    /// what HuggingFace `tokenizers` does under `encode_special_tokens`, which
+    /// `transformers` sets for `split_special_tokens=True`.
+    pub fn split_with<'a>(&self, input: &'a str, skip_special: bool) -> Vec<Segment<'a>> {
         // When there are few distinct start bytes, use SIMD memchr to skip
         // positions that cannot start any added token. This avoids scanning
         // the full input through the Aho-Corasick automaton.
@@ -184,10 +209,12 @@ impl AddedTokens {
             1 => self.split_prefilter(
                 input,
                 memchr::memchr_iter(self.start_bytes[0], input.as_bytes()),
+                skip_special,
             ),
             2 => self.split_prefilter(
                 input,
                 memchr::memchr2_iter(self.start_bytes[0], self.start_bytes[1], input.as_bytes()),
+                skip_special,
             ),
             3 => self.split_prefilter(
                 input,
@@ -197,8 +224,9 @@ impl AddedTokens {
                     self.start_bytes[2],
                     input.as_bytes(),
                 ),
+                skip_special,
             ),
-            _ => self.split_full_scan(input),
+            _ => self.split_full_scan(input, skip_special),
         }
     }
 
@@ -207,12 +235,17 @@ impl AddedTokens {
         &self,
         input: &'a str,
         candidates: impl Iterator<Item = usize>,
+        skip_special: bool,
     ) -> Vec<Segment<'a>> {
         let mut segments = Vec::new();
         let mut prev_end = 0;
+        // End of the last match, emitted or not. A skipped special token still
+        // consumes its span, so a candidate inside it cannot start a second
+        // match — the full-scan path's automaton advances the same way.
+        let mut scan_from = 0;
 
         for pos in candidates {
-            if pos < prev_end {
+            if pos < scan_from {
                 continue;
             }
             // Run the DAAC on a short window starting at this position.
@@ -225,6 +258,10 @@ impl AddedTokens {
             if let Some(m) = self.daac.leftmost_find_iter(window).next()
                 && m.start() == 0
             {
+                if skip_special && self.is_special(m.value()) {
+                    scan_from = pos + m.end();
+                    continue;
+                }
                 let (start, end) =
                     self.strip_bounds(input, m.value(), pos, pos + m.end(), prev_end);
                 if start > prev_end {
@@ -232,6 +269,7 @@ impl AddedTokens {
                 }
                 segments.push(Segment::Token(m.value()));
                 prev_end = end;
+                scan_from = end;
             }
         }
 
@@ -285,11 +323,14 @@ impl AddedTokens {
     }
 
     /// Full-scan fallback for >3 distinct start bytes.
-    fn split_full_scan<'a>(&self, input: &'a str) -> Vec<Segment<'a>> {
+    fn split_full_scan<'a>(&self, input: &'a str, skip_special: bool) -> Vec<Segment<'a>> {
         let mut segments = Vec::new();
         let mut prev_end = 0;
 
         for m in self.daac.leftmost_find_iter(input) {
+            if skip_special && self.is_special(m.value()) {
+                continue;
+            }
             let (start, end) = self.strip_bounds(input, m.value(), m.start(), m.end(), prev_end);
             if start > prev_end {
                 segments.push(Segment::Text(&input[prev_end..start]));
@@ -725,6 +766,102 @@ mod tests {
             at.split("<a><b>"),
             vec![Segment::Token(1), Segment::Token(2)]
         );
+    }
+
+    // ── skip_special (HF `encode_special_tokens`) ───────────────────────
+
+    #[test]
+    fn skip_special_leaves_special_tokens_as_text() {
+        let mut special = make_config(1, "<|user|>");
+        special.special = true;
+        let at = AddedTokens::from_configs(&[special]).unwrap().unwrap();
+
+        assert_eq!(
+            at.split_with("a<|user|>b", false),
+            vec![Segment::Text("a"), Segment::Token(1), Segment::Text("b"),]
+        );
+        assert_eq!(
+            at.split_with("a<|user|>b", true),
+            vec![Segment::Text("a<|user|>b")]
+        );
+    }
+
+    #[test]
+    fn skip_special_keeps_non_special_tokens() {
+        // The distinction HuggingFace draws: only entries flagged `special` are
+        // skipped, so ordinary added vocabulary still tokenizes as itself.
+        let mut special = make_config(1, "<|user|>");
+        special.special = true;
+        let plain = make_config(2, "<think>");
+        let at = AddedTokens::from_configs(&[special, plain])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            at.split_with("<|user|><think>", true),
+            vec![Segment::Text("<|user|>"), Segment::Token(2),]
+        );
+    }
+
+    #[test]
+    fn skip_special_does_not_absorb_whitespace() {
+        // A skipped token is text, so its strip flags must not eat the spaces
+        // around it the way an emitted token would.
+        let at = AddedTokens::from_configs(&[make_strip_config(1, "<s>", true, true)])
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            at.split_with("ab <s> cd", false),
+            vec![Segment::Text("ab"), Segment::Token(1), Segment::Text("cd"),]
+        );
+        assert_eq!(
+            at.split_with("ab <s> cd", true),
+            vec![Segment::Text("ab <s> cd")]
+        );
+    }
+
+    #[test]
+    fn skip_special_consumes_the_matched_span() {
+        // A candidate start byte *inside* a skipped token must not start a
+        // second match: the full-scan automaton advances past the whole match,
+        // and the prefiltered path has to agree.
+        let mut outer = make_config(1, "<a<b>");
+        outer.special = true;
+        let inner = make_config(2, "<b>");
+        let at = AddedTokens::from_configs(&[outer, inner]).unwrap().unwrap();
+
+        assert_eq!(at.split_with("<a<b>", true), vec![Segment::Text("<a<b>")]);
+    }
+
+    #[test]
+    fn skip_special_via_full_scan_path() {
+        // >3 distinct start bytes forces the full-scan path.
+        let mut special = make_config(1, "<bos>");
+        special.special = true;
+        let at = AddedTokens::from_configs(&[
+            special,
+            make_config(2, "[SEP]"),
+            make_config(3, "{pad}"),
+            make_config(4, "|mask|"),
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            at.split_with("<bos>[SEP]", true),
+            vec![Segment::Text("<bos>"), Segment::Token(2),]
+        );
+    }
+
+    #[test]
+    fn configs_are_retained_for_rebuilding() {
+        let configs = vec![
+            make_strip_config(1, "<a>", true, false),
+            make_config(2, "<b>"),
+        ];
+        let at = AddedTokens::from_configs(&configs).unwrap().unwrap();
+        assert_eq!(at.configs(), configs.as_slice());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,12 @@ impl InputCache {
         }
     }
 
+    /// Drop every cached encoding. Required whenever the vocabulary changes,
+    /// since entries were tokenized against the previous one.
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+
     /// Decide how much of `input`'s encoding can be reused from a cached entry.
     /// Returns `None` when nothing worthwhile is shared.
     fn reuse_plan(&self, input: &[u8]) -> Option<Reuse> {
@@ -492,6 +498,69 @@ pub struct EncodeSegment<'a> {
     pub text: &'a str,
     /// Whether special/added tokens are recognized within `text`.
     pub allow_special: bool,
+}
+
+/// Which added-vocabulary entries an encode recognizes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AddedTokenPolicy {
+    /// Recognize every added token. The default.
+    #[default]
+    All,
+    /// Recognize only the added tokens that are not flagged `special`; special
+    /// ones are encoded as ordinary text. Mirrors `encode_special_tokens` in
+    /// HuggingFace `tokenizers`, which is what `transformers` sets for
+    /// `split_special_tokens=True`.
+    SkipSpecial,
+    /// Recognize none: the whole input goes through the base pipeline.
+    None,
+}
+
+/// A token to append to the vocabulary, before an ID is assigned.
+///
+/// Mirrors the fields of an `added_tokens` entry in `tokenizer.json` minus its
+/// ID, which [`Tokenizer::add_tokens`] assigns.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NewToken {
+    /// Literal text content that triggers the token.
+    pub content: String,
+    /// Whether the token should only match as a whole word. Recorded but not
+    /// yet honored by matching, as for tokens declared in `tokenizer.json`.
+    pub single_word: bool,
+    /// Absorb adjacent whitespace on the left when matching.
+    pub lstrip: bool,
+    /// Absorb adjacent whitespace on the right when matching.
+    pub rstrip: bool,
+    /// Whether the content is matched against normalized text. Recorded but not
+    /// yet honored by matching, as for tokens declared in `tokenizer.json`.
+    pub normalized: bool,
+    /// Whether this is a "special" token (e.g. BOS/EOS). Special tokens are
+    /// dropped by `skip_special_tokens` decodes and by
+    /// [`AddedTokenPolicy::SkipSpecial`] encodes.
+    pub special: bool,
+}
+
+impl NewToken {
+    /// An ordinary added token, matched literally.
+    ///
+    /// `normalized` follows upstream's `AddedToken::from`, which sets it for
+    /// ordinary tokens and clears it for special ones. It matters because
+    /// re-adding a token is a no-op only when every field matches.
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            normalized: true,
+            ..Self::default()
+        }
+    }
+
+    /// A special added token (BOS/EOS/control markers).
+    pub fn special(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            special: true,
+            ..Self::default()
+        }
+    }
 }
 
 impl<'a> EncodeSegment<'a> {
@@ -873,6 +942,106 @@ impl Tokenizer {
         self.added_tokens.as_ref()
     }
 
+    /// The added-vocabulary entries, in declaration order.
+    pub fn added_token_configs(&self) -> &[AddedTokenConfig] {
+        self.added_tokens.as_ref().map_or(&[], AddedTokens::configs)
+    }
+
+    /// Extend the vocabulary with `tokens`, returning the entries created or
+    /// changed, in the order given.
+    ///
+    /// IDs are assigned the way HuggingFace `tokenizers` assigns them, so a
+    /// tokenizer extended here and one extended there agree:
+    ///
+    /// - A content already in the added vocabulary keeps its ID; only its flags
+    ///   can change (this is how a token is promoted to `special`). An entry
+    ///   that would not change at all is not reported.
+    /// - A content the model already carries becomes an added token at that
+    ///   same ID, leaving the vocabulary size untouched.
+    /// - Anything else is appended above the vocabulary, contiguously.
+    ///
+    /// The last case is the one serving stacks depend on: a checkpoint whose
+    /// embedding matrix is padded above the tokenizer's token count is squared
+    /// up by appending placeholder tokens until [`Self::vocab_size`] matches the
+    /// embedding count, after which every ID below it resolves.
+    ///
+    /// Empty contents are ignored, as they are upstream. Repeats within one
+    /// call collapse, so a batch can never claim two IDs for one string.
+    pub fn add_tokens(&mut self, tokens: &[NewToken]) -> Result<Vec<AddedTokenConfig>, Error> {
+        let mut configs = self.added_token_configs().to_vec();
+        let mut index_of: HashMap<String, usize> = configs
+            .iter()
+            .enumerate()
+            .map(|(index, config)| (config.content.clone(), index))
+            .collect();
+
+        // Upstream appends above the model vocabulary, unless added IDs already
+        // reach past it — then it continues from the highest one.
+        let model_size = self.model.vocab_size() as u32;
+        let mut next_id = match configs.iter().map(|config| config.id).max() {
+            Some(max) if max >= model_size => max + 1,
+            _ => model_size,
+        };
+
+        let mut changed = Vec::new();
+        for token in tokens {
+            if token.content.is_empty() {
+                continue;
+            }
+            let entry = AddedTokenConfig {
+                // Replaced below; every branch decides its own ID.
+                id: 0,
+                content: token.content.clone(),
+                single_word: token.single_word,
+                lstrip: token.lstrip,
+                rstrip: token.rstrip,
+                normalized: token.normalized,
+                special: token.special,
+            };
+
+            match index_of.get(&token.content).copied() {
+                Some(index) => {
+                    let updated = AddedTokenConfig {
+                        id: configs[index].id,
+                        ..entry
+                    };
+                    if configs[index] == updated {
+                        continue;
+                    }
+                    configs[index] = updated.clone();
+                    changed.push(updated);
+                }
+                None => {
+                    let id = self.model.token_to_id(&token.content).unwrap_or_else(|| {
+                        let id = next_id;
+                        next_id += 1;
+                        id
+                    });
+                    let entry = AddedTokenConfig { id, ..entry };
+                    index_of.insert(token.content.clone(), configs.len());
+                    configs.push(entry.clone());
+                    changed.push(entry);
+                }
+            }
+        }
+
+        if changed.is_empty() {
+            return Ok(changed);
+        }
+
+        // Compile before committing: a rejected set must leave the tokenizer as
+        // it was rather than half-extended.
+        let added_tokens = AddedTokens::from_configs(&configs).map_err(Error::Model)?;
+        self.added_tokens = added_tokens;
+
+        // Cached encodings were produced against the previous vocabulary.
+        if let Some(cache) = &self.input_cache {
+            cache.lock().unwrap().clear();
+        }
+
+        Ok(changed)
+    }
+
     /// Return the decoder, if any.
     pub fn decoder(&self) -> Option<&Decoder> {
         self.decoder.as_ref()
@@ -907,7 +1076,7 @@ impl Tokenizer {
         input: &str,
         add_special_tokens: bool,
     ) -> Result<Vec<u32>, Error> {
-        self.encode_inner(input, add_special_tokens, true)
+        self.encode_inner(input, add_special_tokens, AddedTokenPolicy::All)
     }
 
     /// Encode through the base tokenizer pipeline without recognizing added
@@ -918,7 +1087,21 @@ impl Tokenizer {
     /// bypassed. Normalization, pre-tokenization, model tokenization, and
     /// post-processing are preserved.
     pub fn encode_ordinary(&self, input: &str) -> Result<Vec<u32>, Error> {
-        self.encode_inner(input, false, false)
+        self.encode_inner(input, false, AddedTokenPolicy::None)
+    }
+
+    /// Run the full encoding pipeline under an explicit [`AddedTokenPolicy`].
+    ///
+    /// [`AddedTokenPolicy::SkipSpecial`] is the one the other entry points do
+    /// not cover: control-token strings are encoded as ordinary text while the
+    /// rest of the added vocabulary still matches.
+    pub fn encode_with_policy(
+        &self,
+        input: &str,
+        add_special_tokens: bool,
+        policy: AddedTokenPolicy,
+    ) -> Result<Vec<u32>, Error> {
+        self.encode_inner(input, add_special_tokens, policy)
     }
 
     /// Encode a pre-segmented input, concatenating the token ids of each
@@ -935,13 +1118,21 @@ impl Tokenizer {
     /// No post-processor special tokens (BOS/EOS) are inserted — the caller's
     /// segments are expected to already carry the full rendered sequence.
     pub fn encode_segments(&self, segments: &[EncodeSegment<'_>]) -> Result<Vec<u32>, Error> {
+        fn policy(seg: &EncodeSegment<'_>) -> AddedTokenPolicy {
+            if seg.allow_special {
+                AddedTokenPolicy::All
+            } else {
+                AddedTokenPolicy::None
+            }
+        }
+
         // Single-segment shortcut avoids a second allocation + copy.
         if let [seg] = segments {
-            return self.encode_inner(seg.text, false, seg.allow_special);
+            return self.encode_inner(seg.text, false, policy(seg));
         }
         let mut ids = Vec::new();
         for seg in segments {
-            let seg_ids = self.encode_inner(seg.text, false, seg.allow_special)?;
+            let seg_ids = self.encode_inner(seg.text, false, policy(seg))?;
             if ids.is_empty() {
                 ids = seg_ids;
             } else {
@@ -955,7 +1146,7 @@ impl Tokenizer {
         &self,
         input: &str,
         add_special_tokens: bool,
-        recognize_added_tokens: bool,
+        policy: AddedTokenPolicy,
     ) -> Result<Vec<u32>, Error> {
         if input.is_empty() {
             return if add_special_tokens {
@@ -966,10 +1157,10 @@ impl Tokenizer {
         }
 
         // 1. Normalize the input, optionally recognizing added vocabulary.
-        let mut pts = if recognize_added_tokens {
-            self.build_pre_tokenized(input)
-        } else {
-            self.build_pre_tokenized_ordinary(input)
+        let mut pts = match policy {
+            AddedTokenPolicy::All => self.build_pre_tokenized_with(input, false),
+            AddedTokenPolicy::SkipSpecial => self.build_pre_tokenized_with(input, true),
+            AddedTokenPolicy::None => self.build_pre_tokenized_ordinary(input),
         };
 
         // Fused path: run only Split, then batch-tokenize with inline ByteLevel.
@@ -1218,8 +1409,14 @@ impl Tokenizer {
     /// Build a [`PreTokenizedString`] by splitting on added tokens and
     /// normalizing text segments into a single contiguous buffer.
     pub fn build_pre_tokenized(&self, input: &str) -> PreTokenizedString {
+        self.build_pre_tokenized_with(input, false)
+    }
+
+    /// [`Self::build_pre_tokenized`], optionally leaving special tokens as
+    /// ordinary text (see [`AddedTokens::split_with`]).
+    pub fn build_pre_tokenized_with(&self, input: &str, skip_special: bool) -> PreTokenizedString {
         let segments = match &self.added_tokens {
-            Some(at) => at.split(input),
+            Some(at) => at.split_with(input, skip_special),
             None => vec![Segment::Text(input)],
         };
 
@@ -1619,6 +1816,286 @@ mod local_tests {
                 "id {id} is counted but has no token"
             );
         }
+    }
+
+    // ── add_tokens ──────────────────────────────────────────────────────
+
+    /// A `tokenizer.json`, as text, so the same bytes can be loaded by both
+    /// this crate and HuggingFace `tokenizers` for parity checks.
+    ///
+    /// The model vocabulary is the distinct characters of `chars`, one ID each,
+    /// so any text over them encodes to one ID per character. Added tokens are
+    /// appended above it in the order given.
+    fn tokenizer_json(chars: &str, added: &[(&str, bool)]) -> String {
+        let mut distinct: Vec<char> = chars.chars().collect();
+        distinct.sort_unstable();
+        distinct.dedup();
+        let vocab: serde_json::Map<String, Value> = distinct
+            .iter()
+            .enumerate()
+            .map(|(id, ch)| (ch.to_string(), Value::from(id)))
+            .collect();
+        let base = vocab.len() as u32;
+        let added_tokens: Vec<Value> = added
+            .iter()
+            .enumerate()
+            .map(|(offset, (content, special))| {
+                json!({
+                    "id": base + offset as u32,
+                    "content": content,
+                    "single_word": false,
+                    "lstrip": false,
+                    "rstrip": false,
+                    "normalized": false,
+                    "special": special,
+                })
+            })
+            .collect();
+        json!({
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": added_tokens,
+            "normalizer": null,
+            "pre_tokenizer": null,
+            "post_processor": null,
+            "decoder": null,
+            "model": {"type": "BPE", "vocab": vocab, "merges": []},
+        })
+        .to_string()
+    }
+
+    fn tokenizer_of(chars: &str, added: &[(&str, bool)]) -> Tokenizer {
+        Tokenizer::from_json(serde_json::from_str(&tokenizer_json(chars, added)).unwrap()).unwrap()
+    }
+
+    /// The scenario this exists for: a checkpoint whose embedding matrix is
+    /// padded above the tokenizer's token count. The loader appends placeholder
+    /// tokens until the two agree, then indexes every ID below the count.
+    #[test]
+    fn add_tokens_pads_a_tokenizer_up_to_an_embedding_count() {
+        let mut tok = tokenizer_of("abc", &[("<|endoftext|>", true), ("<think>", false)]);
+        assert_eq!(tok.vocab_size(), 5);
+
+        let num_model_embeddings = 9;
+        let placeholders: Vec<NewToken> = (0..num_model_embeddings - tok.vocab_size())
+            .map(|i| NewToken::new(format!("<|padding_token_{i}|>")))
+            .collect();
+        let added = tok.add_tokens(&placeholders).unwrap();
+
+        assert_eq!(added.len(), 4);
+        assert_eq!(
+            added.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+            vec![5, 6, 7, 8],
+            "placeholders should land contiguously on the padded rows"
+        );
+        assert_eq!(tok.vocab_size(), num_model_embeddings);
+        for id in 0..tok.vocab_size() as u32 {
+            assert!(tok.id_to_token(id).is_some(), "id {id} has no token");
+        }
+        assert_eq!(tok.token_to_id("<|padding_token_0|>"), Some(5));
+    }
+
+    /// ID assignment has to agree with HuggingFace `tokenizers`, since callers
+    /// swap the two backends under the same loader.
+    #[test]
+    fn add_tokens_matches_huggingface() {
+        use std::str::FromStr;
+
+        // Cases: brand-new contents, a repeat of one, a string the model
+        // already carries, and a promotion of an existing added token.
+        let batches: [&[(&str, bool)]; 4] = [
+            &[("<|pad0|>", false), ("<|pad1|>", false)],
+            &[("<|pad0|>", false)],
+            &[("a", false)],
+            &[("<think>", true)],
+        ];
+
+        let json = tokenizer_json("abc", &[("<|endoftext|>", true), ("<think>", false)]);
+        let mut ours = Tokenizer::from_json(serde_json::from_str(&json).unwrap()).unwrap();
+        let mut theirs = tokenizers::Tokenizer::from_str(&json).unwrap();
+
+        for batch in batches {
+            let mine: Vec<NewToken> = batch
+                .iter()
+                .map(|(content, special)| {
+                    if *special {
+                        NewToken::special(*content)
+                    } else {
+                        NewToken::new(*content)
+                    }
+                })
+                .collect();
+            let hf: Vec<tokenizers::AddedToken> = batch
+                .iter()
+                .map(|(content, special)| tokenizers::AddedToken::from(*content, *special))
+                .collect();
+
+            ours.add_tokens(&mine).unwrap();
+            theirs.add_tokens(&hf);
+
+            assert_eq!(
+                ours.vocab_size(),
+                theirs.get_vocab_size(true),
+                "vocabulary size diverged after adding {batch:?}"
+            );
+            for (content, _) in batch {
+                assert_eq!(
+                    ours.token_to_id(content),
+                    theirs.token_to_id(content),
+                    "id diverged for {content:?} after adding {batch:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn add_tokens_is_idempotent() {
+        let mut tok = tokenizer_of("abc", &[("<think>", false)]);
+        let before = tok.vocab_size();
+
+        assert_eq!(
+            tok.add_tokens(&[NewToken::new("<|pad|>")]).unwrap().len(),
+            1
+        );
+        assert_eq!(tok.vocab_size(), before + 1);
+
+        // Re-adding reports nothing changed and claims no second ID, which is
+        // what protects the loaders that re-run their padding step.
+        assert!(
+            tok.add_tokens(&[NewToken::new("<|pad|>")])
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(tok.vocab_size(), before + 1);
+
+        // Re-declaring a token from `tokenizer.json` is a no-op only when every
+        // field matches — upstream compares the whole entry, so a differing
+        // flag is an update rather than a duplicate (see the promotion test).
+        let declared = NewToken {
+            normalized: false,
+            ..NewToken::new("<think>")
+        };
+        assert!(tok.add_tokens(&[declared]).unwrap().is_empty());
+        assert_eq!(tok.vocab_size(), before + 1);
+    }
+
+    #[test]
+    fn add_tokens_collapses_repeats_within_one_batch() {
+        let mut tok = tokenizer_of("abc", &[]);
+        let before = tok.vocab_size();
+
+        let added = tok
+            .add_tokens(&[
+                NewToken::new("<|pad|>"),
+                NewToken::new("<|pad|>"),
+                NewToken::new(""),
+            ])
+            .unwrap();
+
+        assert_eq!(added.len(), 1);
+        assert_eq!(tok.vocab_size(), before + 1);
+    }
+
+    #[test]
+    fn add_tokens_promotes_an_existing_token_to_special() {
+        let mut tok = tokenizer_of("abc", &[("<think>", false)]);
+        let think = tok.token_to_id("<think>").unwrap();
+        assert!(!tok.is_special_token(think));
+        let before = tok.vocab_size();
+
+        let changed = tok.add_tokens(&[NewToken::special("<think>")]).unwrap();
+
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].id, think, "promotion must not move the ID");
+        assert!(tok.is_special_token(think));
+        assert_eq!(tok.vocab_size(), before);
+    }
+
+    #[test]
+    fn add_tokens_keeps_the_id_of_a_string_the_model_already_has() {
+        let mut tok = tokenizer_of("abc", &[]);
+        let a = tok.token_to_id("a").unwrap();
+        let before = tok.vocab_size();
+
+        let changed = tok.add_tokens(&[NewToken::special("a")]).unwrap();
+
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].id, a);
+        assert_eq!(tok.vocab_size(), before, "no new string, no new entry");
+        assert!(tok.is_special_token(a));
+    }
+
+    #[test]
+    fn added_tokens_are_recognized_when_encoding() {
+        let mut tok = tokenizer_of("ab<|pd|>", &[]);
+        tok.add_tokens(&[NewToken::new("<|pd|>")]).unwrap();
+        let pad = tok.token_to_id("<|pd|>").unwrap();
+
+        assert_eq!(
+            tok.encode("a<|pd|>b").unwrap(),
+            vec![
+                tok.token_to_id("a").unwrap(),
+                pad,
+                tok.token_to_id("b").unwrap(),
+            ]
+        );
+        assert_eq!(tok.decode(&[pad], false).unwrap(), "<|pd|>");
+    }
+
+    #[test]
+    fn input_cache_clear_drops_entries() {
+        let mut cache = InputCache::new(2);
+        cache.insert(b"hello world", &[1, 2, 3], vec![(0, 0)]);
+        assert!(cache.reuse_plan(b"hello world").is_some());
+
+        cache.clear();
+        assert!(cache.reuse_plan(b"hello world").is_none());
+    }
+
+    // ── AddedTokenPolicy ────────────────────────────────────────────────
+
+    #[test]
+    fn encode_policy_skips_only_special_added_tokens() {
+        let tok = tokenizer_of(
+            "abc<|user|><think>",
+            &[("<|user|>", true), ("<think>", false)],
+        );
+        let user = tok.token_to_id("<|user|>").unwrap();
+        let think = tok.token_to_id("<think>").unwrap();
+        let text = "a<|user|>b<think>c";
+
+        let all = tok
+            .encode_with_policy(text, false, AddedTokenPolicy::All)
+            .unwrap();
+        assert!(all.contains(&user) && all.contains(&think));
+
+        // The special token becomes its characters; the ordinary added token is
+        // still a single ID.
+        let skip = tok
+            .encode_with_policy(text, false, AddedTokenPolicy::SkipSpecial)
+            .unwrap();
+        let mut expected = tok.encode_ordinary("a<|user|>b").unwrap();
+        expected.push(think);
+        expected.extend(tok.encode_ordinary("c").unwrap());
+        assert_eq!(skip, expected);
+
+        let none = tok
+            .encode_with_policy(text, false, AddedTokenPolicy::None)
+            .unwrap();
+        assert_eq!(none, tok.encode_ordinary(text).unwrap());
+        assert!(!none.contains(&user) && !none.contains(&think));
+    }
+
+    #[test]
+    fn encode_policy_default_is_unchanged_behavior() {
+        let tok = tokenizer_of("abc<|user|>", &[("<|user|>", true)]);
+        let text = "a<|user|>c";
+        assert_eq!(
+            tok.encode_with_policy(text, false, AddedTokenPolicy::default())
+                .unwrap(),
+            tok.encode(text).unwrap()
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

`_TokenizerShim.add_tokens` and `add_special_tokens` returned `0` and threw their
argument away, so the patched `transformers` backend could not grow its
vocabulary. That makes fastokens unusable on any checkpoint whose embedding
matrix is padded above the tokenizer's token count — a common shape. Loaders
reconcile the two by appending placeholder tokens until `len(tokenizer)` reaches
the embedding count and then assert that it did:

```python
tokenizer.add_tokens([f"<|padding_token_{i}|>" for i in range(num_embeddings - len(tokenizer))])
if len(tokenizer) != num_embeddings:
    raise ...   # always, under fastokens
```

The failure is fail-closed at load, so nothing is ever mis-tokenized; the
backend is simply unavailable on those models. Models whose tokenizer and
embedding counts already agree never enter the padding branch, which is why this
went unnoticed.

Tracing it surfaced a second stored-but-unused value: `encode_special_tokens`,
which `transformers` sets for every `split_special_tokens=True` encode. The shim
kept the flag and encoded as though it were unset, so control-token strings in
untrusted text still produced control-token ids. Callers pair that flag with
`add_special_tokens` to promote ordinary added tokens to special first, so both
no-ops had to go for that path to work at all.

## What changed

Vocabulary extension is now native, and ids are assigned the way `tokenizers`
assigns them so the two backends stay interchangeable under the same loader:

- a content already in the added vocabulary keeps its id and only its flags can
  change — this is what promotes a token to `special`;
- a content the model already carries becomes an added token at that same id,
  leaving the vocabulary size untouched;
- anything else is appended contiguously above the vocabulary, which lands
  padding placeholders exactly on the padded embedding rows.

`Tokenizer::add_tokens` compiles the new set before committing it, so a rejected
batch cannot leave a half-extended tokenizer, and it drops the opt-in prefix
cache, whose entries predate the new tokens. `AddedTokenPolicy` threads through
`encode`, adding the `SkipSpecial` mode that leaves special tokens as ordinary
text while the rest of the added vocabulary still matches — the exact rule
upstream applies under `encode_special_tokens`.

On the Python side the shim reads added tokens back from the backend instead of
the constructor JSON, so extensions survive `to_str`, pickling, deepcopy, and
`added_tokens_decoder`. `get_vocab` unions the id scan with the added entries,
which also keeps `len(get_vocab()) == get_vocab_size()` when declared ids leave a
gap.

One divergence is deliberately left alone: `get_vocab_size` answers the full
vocabulary for both values of `with_added_tokens`, where upstream returns the
base vocabulary for `False`. The backend does not track the split, and
over-reporting is the safer direction for callers that size embedding tables or
logit masks from it, so it is documented in place rather than changed here.

## Test plan

- [x] `cargo test` — 264 pass, 16 new. Includes a parity test that runs the same
      batches through `tokenizers` and this crate and compares ids and
      vocabulary sizes across all four cases (new contents, a repeat, a string
      the model already has, a promotion to special).
- [x] New `python/tests/test_add_tokens.py` covers the shim directly: padding up
      to an embedding count, idempotence, promotion, serialization round-trips,
      and special-token splitting. Wired into CI alongside the existing
      transformers job.
- [x] `python/tests/test_patch_transformers.py` asserts end-to-end equality with
      the unpatched backend for both padding and `split_special_tokens`.
- [x] Green on transformers 4.57.1 and 5.3.0 (both patch paths).
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`.

Made with [Cursor](https://cursor.com)